### PR TITLE
Update references to previous repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ While the serial communication is mediated by `/micropython.js`, the local files
 
 ## Running Arduino Lab for MicroPython from source code
 
-1. Clone this repository: `git clone https://github.com/arduino/MicroPython_Lab.git`
-2. Navigate to repository folder: `cd MicroPython_Lab`
+1. Clone this repository: `git clone https://github.com/arduino/lab-micropython-editor.git`
+2. Navigate to repository folder: `cd lab-micropython-editor`
 3. Install dependencies: `npm install`
 4. Run dev mode: `npm run dev`
 

--- a/index.js
+++ b/index.js
@@ -187,14 +187,14 @@ const template = [
         label: 'Learn More',
         click: async () => {
           const { shell } = require('electron')
-          await shell.openExternal('https://github.com/arduino/MicroPython_Lab')
+          await shell.openExternal('https://github.com/arduino/lab-micropython-editor')
         }
       },
       {
         label: 'Report an issue',
         click: async () => {
           const { shell } = require('electron')
-          await shell.openExternal('https://github.com/arduino/MicroPython_Lab/issues')
+          await shell.openExternal('https://github.com/arduino/lab-micropython-editor/issues')
         }
       },
       {
@@ -205,7 +205,7 @@ const template = [
                 css_path: join(__dirname, 'ui/arduino/about.css'),
                 copyright: '© Arduino SA 2022',
                 package_json_dir: __dirname,
-                bug_report_url: "https://github.com/arduino/MicroPython_Lab/issues",
+                bug_report_url: "https://github.com/arduino/lab-micropython-editor/issues",
                 bug_link_text: "report an issue",
                 homepage: "https://labs.arduino.cc",
                 use_version_info: false,


### PR DESCRIPTION
The repository name was changed to "lab-micropython-editor", but some code and documentation still referenced the previous repository name.