### PR TITLE
Sync package version metadata in lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "arduino-lab-micropython-ide",
-	"version": "0.3.1",
+	"version": "0.5.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "arduino-lab-micropython-ide",
-			"version": "0.3.1",
+			"version": "0.5.0",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
The version has been bumped multiple times in `package.json` without updating [`package-lock.json`](https://docs.npmjs.com/cli/v8/configuring-npm/package-lock-json). This resulted in a confusing diff for any contributor who runs `npm install` locally.

I recommend installing a GitHub Actions workflow that checks for out of sync conditions like this. One is available here and already used in Arduino Tooling repositories:

https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-npm-task.md