### PR TITLE
Fix character escaping

### DIFF
--- a/micropython.js
+++ b/micropython.js
@@ -12,7 +12,6 @@ function sleep(millis) {
 }
 
 function escape_string(string) {
-  string = string.replace(/"""/g, `\\"\\"\\"`)
   string = string.replace(/\'/g, `\\'`)
   string = string.replace(/\"/g, `\\"`)
   return string


### PR DESCRIPTION
There was a bug on the character escaping method and the solution was to "double" escape some characters.
A mistake on the code for escaping was causing the triple quote for Python comments to be "triple" escaped. 

This PR fixes specifically the escaping of the characters `'` and `"`.

As seen in https://github.com/arduino/lab-micropython-editor/issues/8