### PR TITLE
fixed disk files sorting. updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ dist
 .history
 dist/
 .vscode
+.npmrc
 Resources
 temp

--- a/index.js
+++ b/index.js
@@ -21,6 +21,11 @@ function listFolder(folder) {
   })
   // Filter out dot files
   files = files.filter(f => f.indexOf('.') !== 0)
+
+  // Sort alphabetically in case-insensitive fashion
+  files.sort(function (a, b) {
+    return a.localeCompare(b);
+  });
   return files
 }
 

--- a/index.js
+++ b/index.js
@@ -19,13 +19,6 @@ function listFolder(folder) {
     let filePath = path.resolve(folder, f)
     return !fs.lstatSync(filePath).isDirectory()
   })
-  // Filter out dot files
-  files = files.filter(f => f.indexOf('.') !== 0)
-
-  // Sort alphabetically in case-insensitive fashion
-  files.sort(function (a, b) {
-    return a.localeCompare(b);
-  });
   return files
 }
 

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -215,12 +215,14 @@ function store(state, emitter) {
         state.serialFiles = state.serialFiles.filter(
           f => f.indexOf('.') !== -1 // Only files with extensions
         )
+        // Filter out dot files
         state.serialFiles = state.serialFiles.filter(
-          f => f.indexOf('.') !== 0 // No dot files
+          f => f.indexOf('.') !== 0
         )
-        state.serialFiles.sort(function (a, b) {
-          return a.localeCompare(b);
-        });
+        // Sort alphabetically in case-insensitive fashion
+        state.serialFiles = state.serialFiles.sort(
+          (a, b) => a.localeCompare(b)
+        )
       } catch (e) {
         console.log('error', e)
       }
@@ -228,6 +230,12 @@ function store(state, emitter) {
     if (state.diskPath) {
       try {
         state.diskFiles = await disk.listFiles(state.diskPath)
+        // Filter out dot files
+        state.diskFiles = state.diskFiles.filter(f => f.indexOf('.') !== 0)
+        // Sort alphabetically in case-insensitive fashion
+        state.diskFiles = state.diskFiles.sort(
+          (a, b) => a.localeCompare(b)
+        )
       } catch (e) {
         console.log('error', e)
       }

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -218,6 +218,9 @@ function store(state, emitter) {
         state.serialFiles = state.serialFiles.filter(
           f => f.indexOf('.') !== 0 // No dot files
         )
+        state.serialFiles.sort(function (a, b) {
+          return a.localeCompare(b);
+        });
       } catch (e) {
         console.log('error', e)
       }


### PR DESCRIPTION
Previously the files would be listed based on their name's characters position in the character table, hence capitalised file names would all be listed first. This PR sorts the files array using a sort function based on localeCompare()