### PR TITLE
Persist local folder path on `localStorage`

### DIFF
--- a/ui/arduino/components/toolbar.js
+++ b/ui/arduino/components/toolbar.js
@@ -48,18 +48,29 @@ function Toolbar(state, emit) {
     onclick: () => emit('open-folder')
   })
 
-  const canSaveBoard = state.isConnected 
-    && state.selectedDevice === 'serial' 
-    && state.selectedFile
-  const canSaveDisk = state.selectedDevice === 'disk' 
-    && state.selectedFile 
-    && state.diskPath
-  const save = Button({
+  let save = Button({
     icon: 'icons/Save.svg',
     label: 'Save',
-    disabled: !canSaveBoard && !canSaveDisk,
-    onclick: () => emit('save')
+    disabled: true,
+    onclick: () => false
   })
+  if (state.selectedDevice === 'serial') {
+    const canSaveBoard = state.isConnected && state.selectedFile
+    save = Button({
+      icon: 'icons/Save.svg',
+      label: 'Save',
+      disabled: !canSaveDisk,
+      onclick: () => emit('save')
+    })
+  } else if (state.selectedDevice === 'disk') {
+    const canSaveDisk = state.selectedFile && state.diskPath
+    save = Button({
+      icon: 'icons/Save.svg',
+      label: 'Save',
+      disabled: !canSaveDisk,
+      onclick: () => emit('save')
+    })
+  }
 
   const terminal = Button({
     icon: 'icons/Output.svg',

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -202,11 +202,11 @@ function store(state, emitter) {
   emitter.on('open-folder', async () => {
     log('open-folder')
     let { folder, files } = await disk.openFolder()
-    // disk.openFolder() returns *string* 'null' because of `ipc`
-    folder = folder === 'null' ? null : folder
-    localStorage.setItem('diskPath', folder)
-    state.diskPath = folder
-    state.diskFiles = files
+    if (folder !== 'null' && folder !== null) {
+      localStorage.setItem('diskPath', folder)
+      state.diskPath = folder
+      state.diskFiles = files
+    }
     if (!state.isFilesOpen) emitter.emit('show-files')
     emitter.emit('render')
   })

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -23,7 +23,7 @@ function store(state, emitter) {
   state.selectedFile = null
   state.selectedDevice = 'disk'
 
-  state.diskPath = null
+  state.diskPath = localStorage.getItem('diskPath')
   state.serialPath = null
 
   state.isConnected = false
@@ -202,6 +202,9 @@ function store(state, emitter) {
   emitter.on('open-folder', async () => {
     log('open-folder')
     let { folder, files } = await disk.openFolder()
+    // disk.openFolder() returns *string* 'null' because of `ipc`
+    folder = folder === 'null' ? null : folder
+    localStorage.setItem('diskPath', folder)
     state.diskPath = folder
     state.diskFiles = files
     if (!state.isFilesOpen) emitter.emit('show-files')
@@ -238,6 +241,7 @@ function store(state, emitter) {
           (a, b) => a.localeCompare(b)
         )
       } catch (e) {
+        state.diskPath = null
         console.log('error', e)
       }
     }


### PR DESCRIPTION
Once user has selected a local folder (file manager) it should remember next time opening the editor.