### PR TITLE
feat(build): Can notarize the macOS app on non-CI

### DIFF
--- a/build_resources/notarize.js
+++ b/build_resources/notarize.js
@@ -18,8 +18,18 @@ const { notarize } = require('electron-notarize');
 
 exports.default = async function notarizing(context) {
 		if (!isCI) {
+			if (
+				typeof process.env.MACOS_FORCE_NOTARIZE === 'string' &&
+				/true/i.test(process.env.MACOS_FORCE_NOTARIZE)
+			  ) {
+				// Hack for manual M1 signing. Set the MACOS_FORCE_NOTARIZE env variable to true, to force notarization when not on a CI. The 'true' is case insensitive.
+				console.log(
+				  `Detected the 'MACOS_FORCE_NOTARIZE' environment variable with '${process.env.MACOS_FORCE_NOTARIZE}' value. Forcing the app notarization, although not on a CI.`
+				);
+			  } else {
 				console.log('Skipping notarization: not on CI.');
 				return;
+			  }
 		}
 		if (process.env.IS_FORK === 'true') {
 				console.log('Skipping the app notarization: building from a fork.');


### PR DESCRIPTION
One can force the macOS app notarization even if not on a CI. Set the `MACOS_FORCE_NOTARIZE` environment variable to `true` to bypass the check and force notarization.