### PR TITLE
Bugfix/windows path

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,10 +40,6 @@ function ilistFolder(folder, filesOnly) {
   return files
 }
 
-function cleanPath(filePath) {
-  return path.resolve(filePath)
-}
-
 // LOCAL FILE SYSTEM ACCESS
 ipcMain.handle('open-folder', async (event) => {
   console.log('ipcMain', 'open-folder')

--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ ipcMain.handle('remove-file', (event, filePath) => {
 ipcMain.handle('rename-file', (event, filePath, newFilePath) => {
   console.log('ipcMain', 'rename-file', filePath, newFilePath)
   fs.renameSync(filePath, newFilePath)
-  return newFilename
+  return true
 })
 
 // WINDOW MANAGEMENT

--- a/index.js
+++ b/index.js
@@ -67,16 +67,14 @@ ipcMain.handle('ilist-files', async (event, folder) => {
   return ilistFolder(folder)
 })
 
-ipcMain.handle('load-file', (event, folder, filename) => {
-  console.log('ipcMain', 'load-file', folder, filename )
-  let filePath = path.resolve(folder, filename)
+ipcMain.handle('load-file', (event, filePath) => {
+  console.log('ipcMain', 'load-file', filePath)
   let content = fs.readFileSync(filePath)
   return content
 })
 
-ipcMain.handle('save-file', (event, folder, filename, content) => {
-  console.log('ipcMain', 'save-file', folder, filename, content)
-  let filePath = path.resolve(folder, filename)
+ipcMain.handle('save-file', (event, filePath, content) => {
+  console.log('ipcMain', 'save-file', filePath, content)
   fs.writeFileSync(filePath, content, 'utf8')
   return true
 })
@@ -92,9 +90,8 @@ ipcMain.handle('update-folder', (event, folder) => {
   return { folder, files }
 })
 
-ipcMain.handle('remove-file', (event, folder, filename) => {
-  console.log('ipcMain', 'remove-file', folder, filename)
-  let filePath = path.resolve(folder, filename)
+ipcMain.handle('remove-file', (event, filePath) => {
+  console.log('ipcMain', 'remove-file', filePath)
   fs.unlinkSync(filePath)
   return true
 })
@@ -105,13 +102,6 @@ ipcMain.handle('rename-file', (event, folder, filename, newFilename) => {
   let newFilePath = path.resolve(folder, newFilename)
   fs.renameSync(filePath, newFilePath)
   return newFilename
-})
-
-ipcMain.handle('clean-path', (event, filePath) => {
-  console.log('ipcMain', 'cleanPath', filePath)
-  const resolvedPath = cleanPath(filePath)
-  console.log('resolved path', resolvedPath)
-  return resolvedPath
 })
 
 // WINDOW MANAGEMENT

--- a/index.js
+++ b/index.js
@@ -96,10 +96,8 @@ ipcMain.handle('remove-file', (event, filePath) => {
   return true
 })
 
-ipcMain.handle('rename-file', (event, folder, filename, newFilename) => {
-  console.log('ipcMain', 'rename-file', folder, filename, newFilename)
-  let filePath = path.resolve(folder, filename)
-  let newFilePath = path.resolve(folder, newFilename)
+ipcMain.handle('rename-file', (event, filePath, newFilePath) => {
+  console.log('ipcMain', 'rename-file', filePath, newFilePath)
   fs.renameSync(filePath, newFilePath)
   return newFilename
 })

--- a/index.js
+++ b/index.js
@@ -40,6 +40,9 @@ function ilistFolder(folder, filesOnly) {
   return files
 }
 
+function cleanPath(filePath) {
+  return path.resolve(filePath)
+}
 
 // LOCAL FILE SYSTEM ACCESS
 ipcMain.handle('open-folder', async (event) => {
@@ -103,6 +106,15 @@ ipcMain.handle('rename-file', (event, folder, filename, newFilename) => {
   fs.renameSync(filePath, newFilePath)
   return newFilename
 })
+
+ipcMain.handle('clean-path', (event, filePath) => {
+  console.log('ipcMain', 'cleanPath', filePath)
+  const resolvedPath = cleanPath(filePath)
+  console.log('resolved path', resolvedPath)
+  return resolvedPath
+})
+
+// WINDOW MANAGEMENT
 
 ipcMain.handle('set-window-size', (event, minWidth, minHeight) => {
   console.log('ipcMain', 'set-window-size', minWidth, minHeight)

--- a/package-lock.json
+++ b/package-lock.json
@@ -299,9 +299,9 @@
 			}
 		},
 		"node_modules/@npmcli/fs/node_modules/semver": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-			"integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -592,9 +592,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.18.36",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.36.tgz",
-			"integrity": "sha512-8egDX8dE50XyXWH6C6PRCNkTP106DuUrvdrednFouDSmCi7IOvrqr0frznfZaHifHH/3aq/7a7v9N4wdXMqhBQ==",
+			"version": "16.18.37",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.37.tgz",
+			"integrity": "sha512-ql+4dw4PlPFBP495k8JzUX/oMNRI2Ei4PrMHgj8oT4VhGlYUzF4EYr0qk2fW+XBVGIrq8Zzk13m4cvyXZuv4pA==",
 			"dev": true
 		},
 		"node_modules/@types/plist": {
@@ -814,9 +814,9 @@
 			}
 		},
 		"node_modules/app-builder-lib/node_modules/semver": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-			"integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -1238,9 +1238,9 @@
 			}
 		},
 		"node_modules/cacache/node_modules/minimatch": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-			"integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.2.tgz",
+			"integrity": "sha512-PZOT9g5v2ojiTL7r1xF6plNHLtOeTpSlDI007As2NlA2aYBMfVom17yqa6QzhmDP8QOhn7LjHTg7DFCVSSa6yg==",
 			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
@@ -2312,9 +2312,9 @@
 			}
 		},
 		"node_modules/electron-rebuild/node_modules/semver": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-			"integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -2687,9 +2687,9 @@
 			}
 		},
 		"node_modules/global-agent/node_modules/semver": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-			"integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
@@ -3570,9 +3570,9 @@
 			}
 		},
 		"node_modules/node-abi/node_modules/semver": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-			"integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -3601,9 +3601,9 @@
 			}
 		},
 		"node_modules/node-api-version/node_modules/semver": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-			"integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -3651,9 +3651,9 @@
 			}
 		},
 		"node_modules/node-gyp/node_modules/semver": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-			"integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"

--- a/preload.js
+++ b/preload.js
@@ -73,6 +73,9 @@ const Serial = {
   },
   exit_raw_repl: async () => {
     return board.exit_raw_repl()
+  },
+  cleanPath: (filePath) => {
+    return '/' + filePath.split('/').filter(f => f).join('/')
   }
 }
 
@@ -98,6 +101,9 @@ const Disk = {
   },
   renameFile: async (folder, oldName, newName) => {
     return ipcRenderer.invoke('rename-file', folder, oldName, newName)
+  },
+  cleanPath: async (filePath) => {
+    return ipcRenderer.invoke('clean-path', filePath)
   }
 }
 

--- a/preload.js
+++ b/preload.js
@@ -1,5 +1,6 @@
 console.log('preload')
 const { contextBridge, ipcRenderer } = require('electron')
+const path = require('path')
 
 const Micropython = require('micropython.js')
 const board = new Micropython()
@@ -53,14 +54,12 @@ const Serial = {
   saveFileContent: async (filename, content, dataConsumer) => {
     return board.fs_save(content || ' ', filename, dataConsumer)
   },
-  uploadFile: async (diskFolder, serialFolder, filename, dataConsumer) => {
-    let src = `${diskFolder}/${filename}`
-    let dest = `${serialFolder}/${filename}`
+  uploadFile: async (src, dest, dataConsumer) => {
     return board.fs_put(src, dest, dataConsumer)
   },
-  downloadFile: async (serialFolder, diskFolder, filename) => {
-    let contents = await Serial.loadFile(`${serialFolder}/${filename}`)
-    return ipcRenderer.invoke('save-file', diskFolder, filename, contents)
+  downloadFile: async (src, dest) => {
+    let contents = await Serial.loadFile(src)
+    return ipcRenderer.invoke('save-file', dest, contents)
   },
   renameFile: async (oldName, newName) => {
     return board.fs_rename(oldName, newName)
@@ -74,8 +73,14 @@ const Serial = {
   exit_raw_repl: async () => {
     return board.exit_raw_repl()
   },
-  cleanPath: (filePath) => {
-    return '/' + filePath.split('/').filter(f => f).join('/')
+  getNavigationPath: (navigation, target) => {
+    return [navigation, target].filter(p => p).join('/')
+  },
+  getFullPath: (root, navigation, file) => {
+    return root + [navigation, file].filter(p => p).join('/')
+  },
+  getParentPath: (filePath) => {
+    return filePath.split('/').slice(0, -1).join('/')
   }
 }
 
@@ -89,21 +94,27 @@ const Disk = {
   ilistFiles: async (folder) => {
     return ipcRenderer.invoke('ilist-files', folder)
   },
-  loadFile: async (folder, file) => {
-    let content = await ipcRenderer.invoke('load-file', folder, file)
+  loadFile: async (filePath) => {
+    let content = await ipcRenderer.invoke('load-file', filePath)
     return new TextDecoder().decode(content)
   },
-  removeFile: async (folder, file) => {
-    return ipcRenderer.invoke('remove-file', folder, file)
+  removeFile: async (filePath) => {
+    return ipcRenderer.invoke('remove-file', filePath)
   },
-  saveFileContent: async (folder, file, content) => {
-    return ipcRenderer.invoke('save-file', folder, file, content)
+  saveFileContent: async (filePath, content) => {
+    return ipcRenderer.invoke('save-file', filePath, content)
   },
-  renameFile: async (folder, oldName, newName) => {
-    return ipcRenderer.invoke('rename-file', folder, oldName, newName)
+  renameFile: async (oldName, newName) => {
+    return ipcRenderer.invoke('rename-file', oldName, newName)
   },
-  cleanPath: async (filePath) => {
-    return ipcRenderer.invoke('clean-path', filePath)
+  getNavigationPath: (navigation, target) => {
+    return path.join(navigation, target)
+  },
+  getFullPath: (root, navigation, file) => {
+    return path.resolve(path.join(root, navigation, file))
+  },
+  getParentPath: (navigation) => {
+    return path.dirname(navigation)
   }
 }
 

--- a/ui/arduino/components/panel_files.js
+++ b/ui/arduino/components/panel_files.js
@@ -84,7 +84,7 @@ function PanelFiles(state, emit) {
         <div class="path">
           ${state.isConnected ? Icon('icons/Connect.svg') : Icon('icons/Disconnect.svg')}
           <a class="full" href="#" onclick=${() => emit('open-port-dialog')}>
-            ${state.isConnected ? state.serialPath : 'Connect'}
+            ${state.isConnected ? state.serialPort : 'Connect'}
           </a>
           ${removeSerial}
           ${newSerial}

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -287,7 +287,6 @@ function store(state, emitter) {
     if (folder !== 'null' && folder !== null) {
       localStorage.setItem('diskPath', folder)
       state.diskPath = folder
-      // state.diskFiles = files
     }
     if (!state.isFilesOpen) emitter.emit('show-files')
     emitter.emit('update-files')
@@ -616,7 +615,6 @@ function store(state, emitter) {
     log('navigate-to', device, localPath)
     state.blocking = true
     emitter.emit('render')
-    // localPath = localPath || '/'
     if (device === 'serial') {
       state.serialNavigation = serial.getNavigationPath(
         state.serialNavigation, localPath

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -384,7 +384,7 @@ function store(state, emitter) {
         contents
       )
       await serial.uploadFile(
-        serial.getFullPath(
+        disk.getFullPath(
           state.diskPath,
           state.diskNavigation,
           state.selectedFile
@@ -431,7 +431,7 @@ function store(state, emitter) {
           state.serialNavigation,
           state.selectedFile
         ),
-        serial.getFullPath(
+        disk.getFullPath(
           state.diskPath,
           state.diskNavigation,
           state.selectedFile

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -417,26 +417,27 @@ function store(state, emitter) {
       let editor = state.cache(AceEditor, 'editor').editor
       let contents = cleanCharacters(editor.getValue())
       editor.setValue(contents)
-      await serial.saveFileContent(
-        serial.getFullPath(
-          state.serialPath,
-          state.serialNavigation,
-          state.selectedFile
-        ),
-        contents
-      )
-      await serial.downloadFile(
-        serial.getFullPath(
-          state.serialPath,
-          state.serialNavigation,
-          state.selectedFile
-        ),
+      if (state.unsavedChanges) {
+        await serial.saveFileContent(
+          serial.getFullPath(
+            state.serialPath,
+            state.serialNavigation,
+            state.selectedFile
+          ),
+          contents,
+          (e) => emitter.emit('message', `Saving ${state.selectedFile} on ${getDeviceName('serial')}. ${e}`)
+        )
+        state.unsavedChanges = false
+      }
+      await disk.saveFileContent(
         disk.getFullPath(
           state.diskPath,
           state.diskNavigation,
           state.selectedFile
-        )
+        ),
+        contents
       )
+
       emitter.emit('message', 'File downloaded!', 500)
       setTimeout(() => emitter.emit('update-files'), 500)
       emitter.emit('render')

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -545,18 +545,17 @@ function store(state, emitter) {
   })
 
   // NAVIGATION
-  emitter.on('navigate-to', async (device, fullPath) => {
-    log('navigate-to', device, fullPath)
+  emitter.on('navigate-to', async (device, localPath) => {
+    log('navigate-to', device, localPath)
     state.blocking = true
     emitter.emit('render')
-    fullPath = fullPath || '/'
+    // localPath = localPath || '/'
     if (device === 'serial') {
-      state.serialNavigation += '/' + fullPath
+      state.serialNavigation += '/' + localPath
       state.serialNavigation = serial.cleanPath(state.serialNavigation)
     }
     if (device === 'disk') {
-      state.diskNavigation += '/' + fullPath
-      state.diskNavigation = await disk.cleanPath(state.diskNavigation)
+      state.diskNavigation = await disk.cleanPath(state.diskNavigation + '/' + localPath)
     }
     if (state.selectedDevice === device) {
       state.selectedFile = null


### PR DESCRIPTION
**Problem:**

File management and navigation on Windows wasn't working because of different path separators and root.
The previous solution of using `cleanPath` on the front end to normalize the path strings.
The path strings is calculated using four state properties:
- `diskPath`: The full path of the "working folder" on your disk
- `diskNavigation`: Tells the current folder you are, relative to `diskPath`
- `serialPath`: The serial port path
- `serialNavigation`: Tells the current folder you are, relative to `serialPath

**Solution:**

Instead of storing the serial port path on `serialPath`, that is now stored on `serialPort`.
`serialPath` is now always `/` since you can't choose a folder inside of your board to be the "working folder"

The function `cleanPath` was replaced by 3 different methods in the `Serial` and `Disk` objects declared on `preload.js`. 

The 3 methods are:
- `getFullPath(root, navigation, file)`: It's going to return the full resolved path
- `getNavigationPath(navigation, target)`: Safely concatenate the `target` to current `navigation`
- `getParentPath(filePath)`: Returns the parent path of a file or folder.

On `Serial` we can always assume UNIX-like filesystem so most of the methods will be basic string manipulation.
On `Disk` we use node's `path` module to comply to OS specification.

All `ipcMain` methods expect now a fully resolved file/folder path.

**Extra:**

Improve speed of downloading files without unsaved changes by simply saving the current editor content on disk.
