### PR TITLE
Bugfix/clean repl before actions

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -23,6 +23,9 @@ const Serial = {
   },
   stop: async () => {
     await board.stop()
+    return Promise.resolve()
+  },
+  exit_raw_repl: async () => {
     await board.exit_raw_repl()
     return Promise.resolve()
   },
@@ -69,9 +72,6 @@ const Serial = {
   },
   createFolder: async (folder) => {
     return await board.fs_mkdir(folder)
-  },
-  exit_raw_repl: async () => {
-    return board.exit_raw_repl()
   },
   getNavigationPath: (navigation, target) => {
     return [navigation, target].filter(p => p).join('/')

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -135,12 +135,14 @@ function store(state, emitter) {
     if (!state.isTerminalOpen) emitter.emit('show-terminal')
     let editor = state.cache(AceEditor, 'editor').editor
     let code = editor.getValue()
+    await serial.stop()
     await serial.run(code)
     emitter.emit('render')
   })
   emitter.on('stop', async () => {
     log('stop')
     await serial.stop()
+    await serial.exit_raw_repl()
     emitter.emit('render')
   })
   emitter.on('reset', async () => {
@@ -173,6 +175,7 @@ function store(state, emitter) {
     emitter.emit('message', `Saving ${filename} on ${deviceName}.`)
 
     if (state.selectedDevice === 'serial') {
+      await serial.stop()
       await serial.saveFileContent(
         serial.getFullPath(
           state.serialPath,
@@ -213,6 +216,7 @@ function store(state, emitter) {
 
     if (confirm(`Do you want to remove ${state.selectedFile} from ${deviceName}?`)) {
       if (state.selectedDevice === 'serial') {
+        await serial.stop()
         await serial.removeFile(state.serialNavigation + '/' + state.selectedFile)
         emitter.emit('new-file', 'serial')
       }
@@ -253,6 +257,7 @@ function store(state, emitter) {
 
     let content = ''
     if (state.selectedDevice === 'serial') {
+      await serial.stop()
       content = await serial.loadFile(
         serial.getFullPath(
           state.serialPath,
@@ -417,6 +422,7 @@ function store(state, emitter) {
       let contents = cleanCharacters(editor.getValue())
       editor.setValue(contents)
       if (state.unsavedChanges) {
+        await serial.stop()
         await serial.saveFileContent(
           serial.getFullPath(
             state.serialPath,
@@ -527,6 +533,7 @@ function store(state, emitter) {
     editor.setValue(contents)
 
     if (state.isConnected && state.selectedDevice === 'serial') {
+      await serial.stop()
       // Ask for confirmation to overwrite existing file
       let confirmation = true
       if (state.serialFiles.find(f => f.path === filename)) {


### PR DESCRIPTION
Problem:
If you type anything on the REPL and click save or run, software and hardware get stuck.

Solution:
Make sure to get a clean REPL before running commands.