### PR TITLE
ensure board os path is root before attempting creating lib folder

### DIFF
--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -100,8 +100,8 @@ function store(state, emitter) {
 
     // Make sure there is a lib folder
     log('creating lib folder')
-    await serial.run('import uos; uos.chdir(\'/\')')
-    await serial.createFolder('lib')
+    // await serial.run('import uos; uos.chdir(\'/\')')
+    await serial.createFolder('/lib')
     state.serialPort = path
     state.serialNavigation = ''
     emitter.emit('update-files')

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -100,6 +100,7 @@ function store(state, emitter) {
 
     // Make sure there is a lib folder
     log('creating lib folder')
+    await serial.run('import uos; uos.chdir(\'/\')')
     await serial.createFolder('lib')
     state.serialPort = path
     state.serialNavigation = ''


### PR DESCRIPTION
When using a mix of `mpremote` and Lab for MicroPython, it might happen that the user has been setting the board path to something other than root via a series of `os.chdir()` commands or other scripts.

The board is only `soft_reset()` at connect time, so the current path is whatever it was before the editor connected.
This PR ensures that a call to `os.chdir('/')` is issued before attempting the creation of the `lib` folder