### PR TITLE
Keyboard shortcuts

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,12 @@
-const { app, BrowserWindow, Menu, ipcMain, dialog } = require('electron')
+const {
+  app,
+  BrowserWindow,
+  Menu,
+  ipcMain,
+  dialog,
+  globalShortcut,
+  webContents
+} = require('electron')
 const path = require('path')
 const fs = require('fs')
 const openAboutWindow = require('about-window').default
@@ -127,6 +135,31 @@ function createWindow () {
   // and load the index.html of the app.
   win.loadFile('ui/arduino/index.html')
 }
+
+app.on('browser-window-focus', function () {
+    globalShortcut.register("CommandOrControl+R", () => {
+      win.webContents.send('run')
+    });
+    globalShortcut.register("CommandOrControl+S", () => {
+      win.webContents.send('save')
+    });
+    globalShortcut.register("CommandOrControl+E", () => {
+      win.webContents.send('stop')
+    });
+    globalShortcut.register("CommandOrControl+W", () => {
+      win.webContents.send('reset')
+    });
+    globalShortcut.register("CommandOrControl+Q", () => {
+      win.webContents.send('connect')
+    });
+});
+app.on('browser-window-blur', function () {
+  globalShortcut.unregister('CommandOrControl+R');
+  globalShortcut.unregister('CommandOrControl+S');
+  globalShortcut.unregister('CommandOrControl+E');
+  globalShortcut.unregister('CommandOrControl+W');
+  globalShortcut.unregister('CommandOrControl+Q');
+});
 
 // TODO: Loading splash screen
 

--- a/index.js
+++ b/index.js
@@ -119,6 +119,7 @@ function createWindow () {
     webPreferences: {
       nodeIntegration: true,
       webSecurity: false,
+      webSecurity: true,
       enableRemoteModule: false,
       preload: path.join(__dirname, "preload.js")
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "arduino-lab-micropython-ide",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "arduino-lab-micropython-ide",
-			"version": "0.8.0",
+			"version": "0.9.0",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "arduino-lab-micropython-ide",
 	"productName": "Arduino Lab for Micropython",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"description": "Arduino Lab for MicroPython is a project sponsored by Arduino, based on original work by Murilo Polese.\nThis is an experimental pre-release software, please direct any questions exclusively to Github issues.",
 	"main": "index.js",
 	"scripts": {

--- a/preload.js
+++ b/preload.js
@@ -132,4 +132,5 @@ contextBridge.exposeInMainWorld('ShortcutListeners', {
   onStop: (callback) => ipcRenderer.on('stop', callback),
   onReset: (callback) => ipcRenderer.on('reset', callback),
   onConnect: (callback) => ipcRenderer.on('connect', callback),
+  onSave: (callback) => ipcRenderer.on('save', callback),
 })

--- a/preload.js
+++ b/preload.js
@@ -126,3 +126,10 @@ const Window = {
 contextBridge.exposeInMainWorld('BridgeSerial', Serial)
 contextBridge.exposeInMainWorld('BridgeDisk', Disk)
 contextBridge.exposeInMainWorld('BridgeWindow', Window)
+
+contextBridge.exposeInMainWorld('ShortcutListeners', {
+  onRun: (callback) => ipcRenderer.on('run', callback),
+  onStop: (callback) => ipcRenderer.on('stop', callback),
+  onReset: (callback) => ipcRenderer.on('reset', callback),
+  onConnect: (callback) => ipcRenderer.on('connect', callback),
+})

--- a/ui/arduino/package-lock.json
+++ b/ui/arduino/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "micropython-lab-arduino-ui",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "micropython-lab-arduino-ui",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "browserify": "^17.0.0",

--- a/ui/arduino/package.json
+++ b/ui/arduino/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micropython-lab-arduino-ui",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Interface for Arduino's MicroPython Lab IDE",
   "main": "index.js",
   "scripts": {

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -689,6 +689,9 @@ function store(state, emitter) {
       emitter.emit('reset')
     }
   })
+  ShortcutListeners.onSave(() => {
+    emitter.emit('save')
+  })
   ShortcutListeners.onConnect(() => {
     emitter.emit('open-port-dialog')
   })

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -674,6 +674,25 @@ function store(state, emitter) {
     state.cache(AceEditor, 'editor').render()
   })
 
+  ShortcutListeners.onRun(() => {
+    if (state.isConnected) {
+      emitter.emit('run')
+    }
+  })
+  ShortcutListeners.onStop(() => {
+    if (state.isConnected) {
+      emitter.emit('stop')
+    }
+  })
+  ShortcutListeners.onReset(() => {
+    if (state.isConnected) {
+      emitter.emit('reset')
+    }
+  })
+  ShortcutListeners.onConnect(() => {
+    emitter.emit('open-port-dialog')
+  })
+
 }
 
 function resizeEditor(state) {


### PR DESCRIPTION
It uses `Q` for opening the port selection dialog, `W` for reset, `E` for stop, `R` for run and `S` to save.


The implementation is a 3 step process:
- Create electron shortcuts here and send messages to the web context https://github.com/arduino/lab-micropython-editor/blob/feature/shortcuts/index.js#L139-L162
- Expose this communication to the electron main through the context bridge https://github.com/arduino/lab-micropython-editor/blob/feature/shortcuts/preload.js#L130-L136
- Call the app events when events come from the main context: https://github.com/arduino/lab-micropython-editor/blob/feature/shortcuts/ui/arduino/store.js#L677-L697

Pending issues:
- Since we are using `R` for run, the item on the app menu "window > reload" is overwritten but it is still displayed. This can be confusing.