### PR TITLE
Pin Python version at 3.11 in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,10 +38,10 @@ jobs:
           node-version: '16'
           registry-url: 'https://registry.npmjs.org'
 
-      # - name: Install Python 2.7
-      #   uses: actions/setup-python@v3
-      #   with:
-      #     python-version: '2.7'
+      - name: Install Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11.x'
 
       - name: Package
         shell: bash


### PR DESCRIPTION
Python 3.12.x is incompatible with the version of the **node-gyp** dependency used by this project ([`9.4.0`](https://github.com/arduino/lab-micropython-editor/blob/9dedd05fe573844db7a2c3f3f964b86f151cb8f8/package-lock.json#L3619)) (https://github.com/nodejs/node-gyp/issues/2869). Previously, the workflow used whichever version of Python was [pre-installed on the GitHub Actions runner machine](https://docs.github.com/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#preinstalled-software). The [Python version was recently updated from 3.11.5 to 3.12.0 in the macOS runner](https://github.com/actions/runner-images/releases/tag/macOS-12%2F20231029.1), which caused the workflow to start failing:

https://github.com/arduino/lab-micropython-editor/actions/runs/7087599689/job/19288228020#step:4:211

```text
> electron-rebuild

- Searching dependency tree
Traceback (most recent call last):
  File "/Users/runner/work/lab-micropython-editor/lab-micropython-editor/node_modules/node-gyp/gyp/gyp_main.py", line 42, in <module>
    import gyp  # noqa: E402
    ^^^^^^^^^^
  File "/Users/runner/work/lab-micropython-editor/lab-micropython-editor/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 9, in <module>
    import gyp.input
  File "/Users/runner/work/lab-micropython-editor/lab-micropython-editor/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 19, in <module>
    from distutils.version import StrictVersion
ModuleNotFoundError: No module named 'distutils'
✖ Rebuild Failed

An unhandled error occurred inside electron-rebuild
node-gyp failed to rebuild '/Users/runner/work/lab-micropython-editor/lab-micropython-editor/node_modules/@serialport/bindings-cpp'.
For more information, rerun with the DEBUG environment variable set to "electron-rebuild".

Error: `gyp` failed with exit code: 1
```

The incompatibility has been fixed in **node-gyp** (https://github.com/nodejs/node-gyp/pull/2923) and released in [version 10.0.0](https://github.com/nodejs/node-gyp/releases/tag/v10.0.0), but it is not trivial to update **node-gyp** because it is a transitive dependency of the [direct **electron-rebuild** dependency](https://github.com/arduino/lab-micropython-editor/blob/9dedd05fe573844db7a2c3f3f964b86f151cb8f8/package.json#L18), which [specifies node-gyp@^9.0.0](https://github.com/arduino/lab-micropython-editor/blob/9dedd05fe573844db7a2c3f3f964b86f151cb8f8/package-lock.json#L2078).

For this reason, the chosen solution is to configure the "GitHub Actions" workflow to use the compatible Python `3.11.x`.

At such time as a new version of **electron-rebuild** is released that indicates compatibility with `node-gyp@^10.0.0` (https://github.com/electron/rebuild/issues/1116) and the project's dependencies are updated, pinning to Python `3.11.x` specifically will no longer be needed. However, it will likely be best practices to leave this [**actions/setup-python**](https://github.com/actions/setup-python) step in the workflow even after that since it allows the version of Python used for the build to be controlled by the project maintainers, and for consistency across all the runner machines (at this time, the preinstalled version on the Linux machine is [`3.10.12`](https://github.com/actions/runner-images/blob/ubuntu22/20231126.1/images/ubuntu/Ubuntu2204-Readme.md#language-and-runtime) and the Windows machine [`3.7.9`](https://github.com/actions/runner-images/blob/win19/20231126.1/images/windows/Windows2019-Readme.md#language-and-runtime)).

---

This fix has already been in use for some time in the `arduino/arduino-ide` repository, which suffered the same breakage: https://github.com/arduino/arduino-ide/pull/2261/commits/97b0bc014c641be66e5153a1b232ef800fe940b4