### PR TITLE
Bugfix/board disconnect

### DIFF
--- a/ui/arduino2/store.js
+++ b/ui/arduino2/store.js
@@ -138,6 +138,7 @@ async function store(state, emitter) {
     emitter.emit('render')
   })
   emitter.on('disconnect', async () => {
+    await serial.disconnect()
     state.isConnected = false
     state.isPanelOpen = false
     state.boardFiles = []


### PR DESCRIPTION
App now awaits for board disconnection making the serial port available to other operations such as `mpremote`