### PR TITLE
Use `getNavigationPath` instead of `getFullPath`

### DIFF
--- a/ui/arduino2/store.js
+++ b/ui/arduino2/store.js
@@ -586,20 +586,18 @@ async function store(state, emitter) {
   // NAVIGATION
   emitter.on('navigate-board-folder', (folder) => {
     log('navigate-board-folder')
-    state.boardNavigationPath = serial.getFullPath(
+    state.boardNavigationPath = serial.getNavigationPath(
       state.boardNavigationPath,
-      folder,
-      ''
+      folder
     )
     emitter.emit('refresh-files')
     emitter.emit('render')
   })
   emitter.on('navigate-board-parent', () => {
     log('navigate-board-parent')
-    state.boardNavigationPath = serial.getFullPath(
+    state.boardNavigationPath = serial.getNavigationPath(
       state.boardNavigationPath,
-      '..',
-      ''
+      '..'
     )
     emitter.emit('refresh-files')
     emitter.emit('render')
@@ -607,20 +605,18 @@ async function store(state, emitter) {
 
   emitter.on('navigate-disk-folder', (folder) => {
     log('navigate-disk-folder')
-    state.diskNavigationPath = disk.getFullPath(
+    state.diskNavigationPath = disk.getNavigationPath(
       state.diskNavigationPath,
-      folder,
-      ''
+      folder
     )
     emitter.emit('refresh-files')
     emitter.emit('render')
   })
   emitter.on('navigate-disk-parent', () => {
     log('navigate-disk-parent')
-    state.diskNavigationPath = disk.getFullPath(
+    state.diskNavigationPath = disk.getNavigationPath(
       state.diskNavigationPath,
-      '..',
-      ''
+      '..'
     )
     emitter.emit('refresh-files')
     emitter.emit('render')
@@ -708,7 +704,7 @@ async function getBoardFiles(path) {
   }))
   files = files.sort(sortFilesAlphabetically)
   return files
-  
+
 }
 
 async function checkDiskFile({ root, parentFolder, fileName }) {


### PR DESCRIPTION
# Problem:

Can't navigate to folders on disk on a Windows machine.

# Reason:

![image](https://github.com/arduino/lab-micropython-editor/assets/954594/c667868d-5420-4df2-a6bb-472932389162)

The issue with folder navigation on Windows was that we were joining two fully resolved paths.

# Solution:

Use the already in place `solveNavigationPath` :x