### PR TITLE
Bugfix: New File Input

### DIFF
--- a/ui/arduino2/views/components/file-list.js
+++ b/ui/arduino2/views/components/file-list.js
@@ -40,7 +40,7 @@ function DiskFileList(state, emit) {
     <div class="item">
       <img class="icon" src="media/file.svg" />
       <div class="text">
-        <input type="text" onblur=${(e) => emit('finish-creating', e.target.value)}/>
+        <input type="text" onkeydown=${onKeyEvent} onblur=${(e) => emit('finish-creating', e.target.value)}/>
       </div>
     </div>
   `
@@ -110,7 +110,7 @@ function BoardFileList(state, emit) {
     <div class="item">
       <img class="icon" src="media/file.svg" />
       <div class="text">
-        <input type="text" onblur=${(e) => emit('finish-creating', e.target.value)}/>
+        <input type="text" onkeydown=${onKeyEvent}  onblur=${(e) => emit('finish-creating', e.target.value)}/>
       </div>
     </div>
   `

--- a/ui/arduino2/views/components/file-list.js
+++ b/ui/arduino2/views/components/file-list.js
@@ -60,7 +60,6 @@ function DiskFileList(state, emit) {
     const el = list.querySelector('input')
     if (el) {
       el.focus()
-      observer.disconnect()
     }
   })
   observer.observe(list, { childList: true, subtree:true })
@@ -129,7 +128,6 @@ function BoardFileList(state, emit) {
     const el = list.querySelector('input')
     if (el) {
       el.focus()
-      observer.disconnect()
     }
   })
   observer.observe(list, { childList: true, subtree:true })


### PR DESCRIPTION
The "new file" input PR has been merged with a bug where the `onKeyEvent` is created but not bound to the DOM element:
https://github.com/arduino/lab-micropython-editor/pull/86

@ubidefeo also found a bug where after pressing `ESC` to cancel the new file action, the input wouldn't appear focused anymore.

This PR addressed those two problems.