### PR TITLE
GH Workflow changes to produce properly named artefacts 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Arduino MicroPython Lab
+name: Arduino Lab for MicroPython
 
 on:
   push:
@@ -104,7 +104,7 @@ jobs:
           # - path: "*Windows_64bit.msi"
           #   name: Windows_X86-64_MSI
           - path: "*-win_x64.zip"
-            name: Arduino-Lab-for-MicroPython_Windows_X86-64_zip
+            name: Arduino-Lab-for-MicroPython_Windows_X86-64
 
     steps:
       - name: Download job transfer artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,15 +96,15 @@ jobs:
       matrix:
         artifact:
           - path: "*-linux_x64.zip"
-            name: Linux_X86-64
+            name: Arduino-Lab-for-MicroPython_Linux_X86-64
           - path: "*-mac_x64.zip"
-            name: macOS
+            name: Arduino-Lab-for-MicroPython_macOS_X86-64
           # - path: "*Windows_64bit.exe"
           #   name: Windows_X86-64_interactive_installer
           # - path: "*Windows_64bit.msi"
           #   name: Windows_X86-64_MSI
           - path: "*-win_x64.zip"
-            name: Windows_X86-64_zip
+            name: Arduino-Lab-for-MicroPython_Windows_X86-64_zip
 
     steps:
       - name: Download job transfer artifact


### PR DESCRIPTION
With these changes, the produced artefacts will have a better formatted name

| current artefact name | new name | extension |
| - | - | - |
| Linux_X86-64 | Arduino-Lab-for-MicroPython_Linux_X86-64 | zip |
| Windows_X86-64_zip | Arduino-Lab-for-MicroPython_Windows_X86-64 | zip |
| macOS | Arduino-Lab-for-MicroPython_macOS_X86-64 | zip |

The output results have been verified through Action Run #141, which prompted for commit `368278dda11a495cb5fa83f4c98d4ac3dd5274ea` in order to remove the Windows' `_zip` suffix on the file name