### PR TITLE
[WIP] Add build target for Apple Silicon

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,15 @@ on:
   pull_request:
     branches:
       - develop
+  # schedule:
+  #   - cron: '0 3 * * *' # run every day at 3AM (https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
 
 env:
   JOB_TRANSFER_ARTIFACT: build-artifacts
 
 jobs:
   build:
-    if: github.repository == 'arduino/lab-micropython-editor'
+    if: github.repository == 'arduino/MicroPython_Lab'
     strategy:
       fail-fast: false
       matrix:
@@ -30,18 +32,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
-      - name: Install Node.js 16.x
-        uses: actions/setup-node@v3
+      - name: Install Node.js 14.x
+        uses: actions/setup-node@v1
         with:
-          node-version: '16'
+          node-version: '14'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install Python 3.x
-        uses: actions/setup-python@v4
+      - name: Install Python 2.7
+        uses: actions/setup-python@v2
         with:
-          python-version: '3.11.x'
+          python-version: '2.7'
 
       - name: Package
         shell: bash
@@ -49,7 +51,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
-          AC_TEAM_ID: ${{ secrets.AC_TEAM_ID }}
           # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           # IS_NIGHTLY: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
@@ -81,7 +82,7 @@ jobs:
             npm run build
 
       - name: Upload [GitHub Actions]
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ env.JOB_TRANSFER_ARTIFACT }}
           path: dist
@@ -105,27 +106,97 @@ jobs:
           #   name: Windows_X86-64_MSI
           - path: "*-win_x64.zip"
             name: Windows_X86-64_zip
+          
+          # THIS IS MESSED UP
+          # artifact:
+          # - path: "*.AppImage*.zip"
+          #   name: Linux_X86-64
+          # - path: "*-mac*.zip"
+          #   name: macOS
 
     steps:
       - name: Download job transfer artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v2
         with:
           name: ${{ env.JOB_TRANSFER_ARTIFACT }}
           path: ${{ env.JOB_TRANSFER_ARTIFACT }}
-
+      
       - name: Upload tester build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.artifact.name }}
           path: ${{ env.JOB_TRANSFER_ARTIFACT }}/${{ matrix.artifact.path }}
 
+  # changelog:
+  #   needs: build
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     BODY: ${{ steps.changelog.outputs.BODY }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0 # To fetch all history for all branches and tags.
+
+  #     - name: Generate Changelog
+  #       id: changelog
+  #       env:
+  #         IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/') }}
+  #       run: |
+  #           export LATEST_TAG=$(git describe --abbrev=0)
+  #           export GIT_LOG=$(git log --pretty=" - %s [%h]" $LATEST_TAG..HEAD | sed 's/ *$//g')
+  #           if [ "$IS_RELEASE" = true ]; then
+  #             export BODY=$(echo -e "$GIT_LOG")
+  #           else 
+  #             export LATEST_TAG_WITH_LINK=$(echo "[$LATEST_TAG](https://github.com/arduino/arduino-ide/releases/tag/$LATEST_TAG)")
+  #             if [ -z "$GIT_LOG" ]; then
+  #                 export BODY="There were no changes since version $LATEST_TAG_WITH_LINK."
+  #             else
+  #                 export BODY=$(echo -e "Changes since version $LATEST_TAG_WITH_LINK:\n$GIT_LOG")
+  #             fi
+  #           fi
+  #           echo -e "$BODY"
+  #           OUTPUT_SAFE_BODY="${BODY//'%'/'%25'}"
+  #           OUTPUT_SAFE_BODY="${OUTPUT_SAFE_BODY//$'\n'/'%0A'}"
+  #           OUTPUT_SAFE_BODY="${OUTPUT_SAFE_BODY//$'\r'/'%0D'}"
+  #           echo "::set-output name=BODY::$OUTPUT_SAFE_BODY"
+  #           echo "$BODY" > CHANGELOG.txt
+
+  #     - name: Upload Changelog [GitHub Actions]
+  #       if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: ${{ env.JOB_TRANSFER_ARTIFACT }}
+  #         path: CHANGELOG.txt
+
+  # publish:
+  #   needs: changelog
+  #   if: github.repository == 'arduino/arduino-ide' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'))
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Download [GitHub Actions]
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: ${{ env.JOB_TRANSFER_ARTIFACT }}
+  #         path: ${{ env.JOB_TRANSFER_ARTIFACT }}
+
+  #     # - name: Publish Nightly [S3]
+  #     #   uses: docker://plugins/s3
+  #     #   env:
+  #     #     PLUGIN_SOURCE: "${{ env.JOB_TRANSFER_ARTIFACT }}/*"
+  #     #     PLUGIN_STRIP_PREFIX: "${{ env.JOB_TRANSFER_ARTIFACT }}/"
+  #     #     PLUGIN_TARGET: "/arduino-ide/nightly"
+  #     #     PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
+  #     #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #     #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
   release:
     needs: build
-    if: github.repository == 'arduino/lab-micropython-editor' && startsWith(github.ref, 'refs/tags/')
+    if: github.repository == 'arduino/MicroPython_Lab' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - name: Download [GitHub Actions]
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v2
         with:
           name: ${{ env.JOB_TRANSFER_ARTIFACT }}
           path: ${{ env.JOB_TRANSFER_ARTIFACT }}
@@ -143,11 +214,23 @@ jobs:
           file: ${{ env.JOB_TRANSFER_ARTIFACT }}/*
           tag: ${{ github.ref }}
           file_glob: true
+          # body: ${{ needs.changelog.outputs.BODY }}
+
+      # - name: Publish Release [S3]
+      #   uses: docker://plugins/s3
+      #   env:
+      #     PLUGIN_SOURCE: "${{ env.JOB_TRANSFER_ARTIFACT }}/*"
+      #     PLUGIN_STRIP_PREFIX: "${{ env.JOB_TRANSFER_ARTIFACT }}/"
+      #     PLUGIN_TARGET: "/arduino-ide"
+      #     PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   clean:
     # This job must run after all jobs that use the transfer artifact.
     needs:
       - build
+      # - publish
       - release
       - artifacts
     if: always() && needs.build.result != 'skipped'
@@ -155,6 +238,6 @@ jobs:
 
     steps:
       - name: Remove unneeded job transfer artifact
-        uses: geekyeggo/delete-artifact@v2
+        uses: geekyeggo/delete-artifact@v1
         with:
           name: ${{ env.JOB_TRANSFER_ARTIFACT }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,8 @@ jobs:
         config:
           - os: windows-2019
           - os: ubuntu-latest
-          - os: macos-latest
+          - os: macos-13      # Last supported version for Apple x86 runners
+          - os: macos-14      # First supported version for Apple Silicon runners
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 90
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"post-set-shell": "npm config set script-shell bash",
 		"rebuild": "electron-rebuild",
 		"dev": "electron  --inspect ./",
-		"build": "npm run post-set-shell && electron-builder $(if [ $(uname -m) =  arm64 ]; then echo --mac --x64; fi)",
+		"build": "npm run post-set-shell && electron-builder",
 		"postinstall": "npm run post-set-shell && npm run rebuild"
 	},
 	"devDependencies": {


### PR DESCRIPTION
This change hopefully _adds_ Apple Silicon build support as requested in #19.

* A new build matrix os is added. This takes "advantage" of the fact that latest macOS for `x64` runners is macOS 13, where the new runners are at least macOS 14. 
* The force build of `x64` on any macOS runner (see `package.json`) has been removed.  In theory, this means that `electron-build` will generate its artifacts based on the architecture of the runner. 

@ubidefeo I understand that priority is for bug fixes etc. This PR is being raised as a starting point only (hence WIP), any feedback would be appreciated. 