### PR TITLE
[WIP] Add support for an Apple Silicon build target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,8 @@ jobs:
         config:
           - os: windows-2019
           - os: ubuntu-latest
-          - os: macos-latest
+          - os: macos-13    # Last macOS version supported for x86 runners
+          - os: macos-14    # First macOS version support for Apple Silicon runners
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 90
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"post-set-shell": "npm config set script-shell bash",
 		"rebuild": "electron-rebuild",
 		"dev": "electron  --inspect ./",
-		"build": "npm run post-set-shell && electron-builder $(if [ $(uname -m) =  arm64 ]; then echo --mac --x64; fi)",
+		"build": "npm run post-set-shell && electron-builder",
 		"postinstall": "npm run post-set-shell && npm run rebuild"
 	},
 	"devDependencies": {


### PR DESCRIPTION
This change hopefully _adds_ Apple Silicon build support as requested in #19.

* A new build matrix os is added. This takes "advantage" of the fact that latest macOS for `x64` runners is macOS 13, where the new runners are at least macOS 14.
* The force build of `x64` on any macOS runner (see `package.json`) has been removed.  In theory, this means that `electron-build` will generate its artifacts based on the architecture of the runner.

@ubidefeo I understand that priority is for bug fixes etc. This PR is being raised as a starting point only (hence WIP/draft), any feedback would be appreciated.