### PR TITLE
Alert user before closing tab with unsaved changes

### DIFF
--- a/ui/arduino/views/components/elements/editor.js
+++ b/ui/arduino/views/components/elements/editor.js
@@ -7,11 +7,11 @@ class CodeMirrorEditor extends Component {
 
   load(el) {
     const onCodeChange = (update) => {
-      this.content = update.state.doc.toString()
       // console.log('code change', this.content)
+      this.content = update.state.doc.toString()
+      this.onChange()
     }
     this.editor = createEditor(this.content, el, onCodeChange)
-
   }
 
   createElement(content) {
@@ -20,6 +20,10 @@ class CodeMirrorEditor extends Component {
   }
 
   update() {
+    return false
+  }
+
+  onChange() {
     return false
   }
 }

--- a/ui/arduino/views/components/elements/tab.js
+++ b/ui/arduino/views/components/elements/tab.js
@@ -8,7 +8,8 @@ function Tab(args) {
     onFinishRenaming = () => false,
     disabled = false,
     active = false,
-    renaming = false
+    renaming = false,
+    hasChanges = false
   } = args
 
   if (active) {
@@ -41,7 +42,9 @@ function Tab(args) {
       return html`
         <div class="tab active" tabindex="0">
           <img class="icon" src="media/${icon}" />
-          <div class="text" ondblclick=${onStartRenaming}>${text}</div>
+          <div class="text" ondblclick=${onStartRenaming}>
+            ${hasChanges ? ' *' : ''} ${text}
+          </div>
           <div class="options" >
             <button onclick=${onCloseTab}>
               <img class="icon" src="media/close.svg" />
@@ -65,7 +68,9 @@ function Tab(args) {
       onclick=${selectTab}
       >
       <img class="icon" src="media/${icon}" />
-      <div class="text">${text}</div>
+      <div class="text">
+        ${hasChanges ? '*' : ''} ${text}
+      </div>
       <div class="options">
         <button onclick=${onCloseTab}>
           <img class="icon" src="media/close.svg" />

--- a/ui/arduino/views/components/tabs.js
+++ b/ui/arduino/views/components/tabs.js
@@ -7,6 +7,7 @@ function Tabs(state, emit) {
           icon: file.source === 'board'? 'connect.svg': 'computer.svg',
           active: file.id === state.editingFile,
           renaming: file.id === state.renamingTab,
+          hasChanges: file.hasChanges,
           onSelectTab: () => emit('select-tab', file.id),
           onCloseTab: () => emit('close-tab', file.id),
           onStartRenaming: () => emit('rename-tab', file.id),


### PR DESCRIPTION
**Summary:**

Prompt user with a native confirmation dialog when they are closing a file that has unsaved changes.

**Solution:**

We had a CodeMirror plugin already in place to update the content on a class property so the place to send a signal about code change was already in place.

Since we instantiate the `CodeMirrorEditor` instance through choo's cache, we can't pass a callback through parameters so we need to do a method overwrite. I thought it would be natural to call it `onChange` and be called without arguments.

On the `store.js` file, we instantiate a new file when we start the app and when we open a file. I overwrote the default `onChange` method by a local function that sets the file object property `hasChange` to `true` and calls for a screen re-render.

The `hasChanges` property won't compare previous and current content of the tab but if the file has received any new input, it will trigger there are changes if you write and erase what you wrote.