### PR TITLE
Feature/remember scroll position

### DIFF
--- a/ui/arduino/views/components/elements/editor.js
+++ b/ui/arduino/views/components/elements/editor.js
@@ -6,37 +6,39 @@ class CodeMirrorEditor extends Component {
     this.scrollTop = 0
   }
 
+  createElement(content) {
+    if (content) this.content = content
+    return html`<div id="code-editor"></div>`
+  }
+
+
   load(el) {
     const onCodeChange = (update) => {
       this.content = update.state.doc.toString()
       this.onChange()
     }
     this.editor = createEditor(this.content, el, onCodeChange)
-    this.editor.scrollDOM.addEventListener('scroll', this.updateScrollPosition.bind(this))
+
     setTimeout(() => {
+      this.editor.scrollDOM.addEventListener('scroll', this.updateScrollPosition.bind(this))
       this.editor.scrollDOM.scrollTo({
         top: this.scrollTop,
         left: 0
       })
-    }, 1)
+    }, 10)
   }
 
-  updateScrollPosition(e) {
-    console.log(e.target.scrollTop)
-    this.scrollTop = e.target.scrollTop
+  update() {
+    return false
   }
 
   unload() {
     this.editor.scrollDOM.removeEventListener('scroll', this.updateScrollPosition)
   }
 
-  createElement(content) {
-    if (content) this.content = content
-    return html`<div id="code-editor"></div>`
-  }
-
-  update() {
-    return false
+  updateScrollPosition(e) {
+    console.log(e.target.scrollTop)
+    this.scrollTop = e.target.scrollTop
   }
 
   onChange() {

--- a/ui/arduino/views/components/elements/editor.js
+++ b/ui/arduino/views/components/elements/editor.js
@@ -3,15 +3,31 @@ class CodeMirrorEditor extends Component {
     super()
     this.editor = null
     this.content = '# empty file'
+    this.scrollTop = 0
   }
 
   load(el) {
     const onCodeChange = (update) => {
-      // console.log('code change', this.content)
       this.content = update.state.doc.toString()
       this.onChange()
     }
     this.editor = createEditor(this.content, el, onCodeChange)
+    this.editor.scrollDOM.addEventListener('scroll', this.updateScrollPosition.bind(this))
+    setTimeout(() => {
+      this.editor.scrollDOM.scrollTo({
+        top: this.scrollTop,
+        left: 0
+      })
+    }, 1)
+  }
+
+  updateScrollPosition(e) {
+    console.log(e.target.scrollTop)
+    this.scrollTop = e.target.scrollTop
+  }
+
+  unload() {
+    this.editor.scrollDOM.removeEventListener('scroll', this.updateScrollPosition)
   }
 
   createElement(content) {

--- a/ui/arduino/views/components/elements/editor.js
+++ b/ui/arduino/views/components/elements/editor.js
@@ -37,7 +37,6 @@ class CodeMirrorEditor extends Component {
   }
 
   updateScrollPosition(e) {
-    console.log(e.target.scrollTop)
     this.scrollTop = e.target.scrollTop
   }
 

--- a/ui/arduino/views/components/elements/tab.js
+++ b/ui/arduino/views/components/elements/tab.js
@@ -57,7 +57,7 @@ function Tab(args) {
   }
 
   function selectTab(e) {
-    if(e.target.tagName === 'BUTTON' || e.target.tagName === 'IMG') return
+    if(e.target.classList.contains('close-tab')) return
     onSelectTab(e)
   }
 
@@ -71,9 +71,9 @@ function Tab(args) {
       <div class="text">
         ${hasChanges ? '*' : ''} ${text}
       </div>
-      <div class="options">
-        <button onclick=${onCloseTab}>
-          <img class="icon" src="media/close.svg" />
+      <div class="options close-tab">
+        <button class="close-tab" onclick=${onCloseTab}>
+          <img class="close-tab icon" src="media/close.svg" />
         </button>
       </div>
     </div>


### PR DESCRIPTION
# Problem

When switching between tabs the scroll position is lost.

# Solution

We need to make sure when an editor is rendered, it scrolls back to where it was.
The `state.openFiles` objects have the instance of choo's component under the `editor` property.
Each choo component stores their own state independently of the main application state, so it makes sense to store the scroll position there instead of the main state.

# Not cool

I think there is an edge case with large files that they take some time to fully load and that messes

The scroll listener and `scrollTo` are made in a timeout callback because I can't find out how to get a `ready` event from CodeMirror. :shrug: 

# Extra

I noticed that the tab wasn't being selected when you click on the device icon (cables or computer) so I wrote a little fix for that too.