### PR TITLE
GitHub/apple silicon build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,8 @@ jobs:
             name: Arduino-Lab-for-MicroPython_Linux_X86-64
           - path: "*-mac_x64.zip"
             name: Arduino-Lab-for-MicroPython_macOS_X86-64
+          - path: "*-mac_arm64.zip"
+            name: Arduino-Lab-for-MicroPython_macOS_arm-64
           # - path: "*Windows_64bit.exe"
           #   name: Windows_X86-64_interactive_installer
           # - path: "*Windows_64bit.msi"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,8 @@ jobs:
         config:
           - os: windows-2019
           - os: ubuntu-latest
-          - os: macos-latest
+          - os: macos-13
+          - os: macos-14
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 90
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arduino-lab-micropython-ide",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arduino-lab-micropython-ide",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "post-set-shell": "npm config set script-shell bash",
     "rebuild": "electron-rebuild",
     "dev": "electron  --inspect ./",
-    "build": "npm run post-set-shell && electron-builder $(if [ $(uname -m) =  arm64 ]; then echo --mac --x64; fi)",
+    "build": "npm run post-set-shell && electron-builder",
     "postinstall": "npm run post-set-shell && npm run rebuild"
   },
   "devDependencies": {


### PR DESCRIPTION
Building a Mac OS for Apple Silicon version greatly enhances startup times.
While the X86 build takes between 3 and 6 seconds on my Machine (MacBook Pro M1 Max 24 cores), the native Apple Silicon takes less than 1 second.

First startup time went from 9 seconds to 2.

Artefacts are correctly generated and uploaded, and the hack on `package.json` to always trigger `--x64` on `electron builder`  is no more necessary