### PR TITLE
Bugfix/startup selecting folder

### DIFF
--- a/backend/menu.js
+++ b/backend/menu.js
@@ -4,7 +4,6 @@ const openAboutWindow = require('about-window').default
 
 module.exports = function registerMenu(win) {
   const isMac = process.platform === 'darwin'
-  const isDev = !app.isPackaged
   const template = [
     ...(isMac ? [{
       label: app.name,
@@ -56,17 +55,13 @@ module.exports = function registerMenu(win) {
       label: 'View',
       submenu: [
         { role: 'reload' },
+        { role: 'toggleDevTools' },
         { type: 'separator' },
         { role: 'resetZoom' },
         { role: 'zoomIn' },
         { role: 'zoomOut' },
         { type: 'separator' },
         { role: 'togglefullscreen' },
-        ...(isDev ? [
-          { type: 'separator' },
-          { role: 'toggleDevTools' },
-        ]:[
-        ])
       ]
     },
     {

--- a/preload.js
+++ b/preload.js
@@ -13,10 +13,10 @@ const Serial = {
     return ports.filter(p => p.vendorId && p.productId)
   },
   connect: async (path) => {
-    return await board.open(path)
+    return board.open(path)
   },
   disconnect: async () => {
-    return await board.close()
+    return board.close()
   },
   run: async (code) => {
     return board.run(code)

--- a/ui/arduino/index.html
+++ b/ui/arduino/index.html
@@ -30,6 +30,7 @@
     <script type="text/javascript" src="views/components/repl-panel.js" charset="utf-8"></script>
     <script type="text/javascript" src="views/components/tabs.js" charset="utf-8"></script>
     <script type="text/javascript" src="views/components/toolbar.js" charset="utf-8"></script>
+    <script type="text/javascript" src="views/components/overlay.js" charset="utf-8"></script>
 
     <!-- Views -->
     <script type="text/javascript" src="views/editor.js" charset="utf-8"></script>

--- a/ui/arduino/main.js
+++ b/ui/arduino/main.js
@@ -48,7 +48,9 @@ window.addEventListener('load', () => {
   app.mount('#app')
 
   app.emitter.on('DOMContentLoaded', () => {
-    app.emitter.emit('refresh-files')
+    if (app.state.diskNavigationRoot) {
+      app.emitter.emit('refresh-files')
+    }
   })
 
 })

--- a/ui/arduino/main.js
+++ b/ui/arduino/main.js
@@ -19,27 +19,26 @@ function App(state, emit) {
     `
   }
 
-  let overlay = html`<div id="overlay" class="closed"></div>`
-
-  if (state.diskFiles == null) {
-    emit('load-disk-files')
-    overlay = html`<div id="overlay" class="open"><p>Loading files...</p></div>`
+  if (state.view == 'file-manager') {
+    return html`
+      <div id="app">
+        ${FileManagerView(state, emit)}
+        ${Overlay(state, emit)}
+      </div>
+    `
+  } else {
+    return html`
+      <div id="app">
+        ${EditorView(state, emit)}
+        ${Overlay(state, emit)}
+      </div>
+    `
   }
-
-  if (state.isRemoving) overlay = html`<div id="overlay" class="open"><p>Removing...</p></div>`
-  if (state.isConnecting) overlay = html`<div id="overlay" class="open"><p>Connecting...</p></div>`
-  if (state.isLoadingFiles) overlay = html`<div id="overlay" class="open"><p>Loading files...</p></div>`
-  if (state.isSaving) overlay = html`<div id="overlay" class="open"><p>Saving file... ${state.savingProgress}</p></div>`
-  if (state.isTransferring) overlay = html`<div id="overlay" class="open"><p>Transferring file... ${state.transferringProgress}</p></div>`
-
-  const view = state.view == 'editor' ? EditorView(state, emit) : FileManagerView(state, emit)
   return html`
     <div id="app">
-      ${view}
-      ${overlay}
+      ${Overlay(state, emit)}
     </div>
   `
-
 }
 
 window.addEventListener('load', () => {

--- a/ui/arduino/views/components/overlay.js
+++ b/ui/arduino/views/components/overlay.js
@@ -1,0 +1,16 @@
+function Overlay(state, emit) {
+  let overlay = html`<div id="overlay" class="closed"></div>`
+
+  if (state.diskFiles == null) {
+    emit('load-disk-files')
+    overlay = html`<div id="overlay" class="open"><p>Loading files...</p></div>`
+  }
+
+  if (state.isRemoving) overlay = html`<div id="overlay" class="open"><p>Removing...</p></div>`
+  if (state.isConnecting) overlay = html`<div id="overlay" class="open"><p>Connecting...</p></div>`
+  if (state.isLoadingFiles) overlay = html`<div id="overlay" class="open"><p>Loading files...</p></div>`
+  if (state.isSaving) overlay = html`<div id="overlay" class="open"><p>Saving file... ${state.savingProgress}</p></div>`
+  if (state.isTransferring) overlay = html`<div id="overlay" class="open"><p>Transferring file... ${state.transferringProgress}</p></div>`
+
+  return overlay
+}


### PR DESCRIPTION
# Problem

- First time opening the app the UI would always get stuck after selecting the local folder
- When opening two instances, it would be like opening the app for the first time so it would also get stuck

# Solution

Make sure there is a `state.diskNavigationRoot` set before triggering a `refresh-files` event

# Extra

- Created a component for the overlay messages to cleanup `main.js`
- Re-enabled Chrome DevTools on production builds
