### PR TITLE
Extra resource

### DIFF
--- a/backend/ipc.js
+++ b/backend/ipc.js
@@ -113,6 +113,15 @@ module.exports = function registerIPCHandlers(win, ipcMain, app) {
     app.exit()
   })
 
+  ipcMain.handle('is-packaged', () => {
+    return app.isPackaged
+  })
+
+  ipcMain.handle('get-app-path', () => {
+    console.log('ipcMain', 'get-app-path')
+    return app.getAppPath()
+  })
+
   win.on('close', (event) => {
     console.log('BrowserWindow', 'close')
     event.preventDefault()

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "build": {
     "appId": "cc.arduino.micropython-lab",
     "artifactName": "${productName}-${os}_${arch}.${ext}",
+    "extraResources": "./ui/arduino/helpers.py",
     "mac": {
       "target": "zip",
       "icon": "build_resources/icon.icns"

--- a/preload.js
+++ b/preload.js
@@ -145,6 +145,9 @@ const Disk = {
   },
   fileExists: async (filePath) => {
     return ipcRenderer.invoke('file-exists', filePath)
+  },
+  getAppPath: () => {
+    return ipcRenderer.invoke('get-app-path')
   }
 }
 
@@ -153,7 +156,8 @@ const Window = {
     ipcRenderer.invoke('set-window-size', minWidth, minHeight)
   },
   beforeClose: (callback) => ipcRenderer.on('check-before-close', callback),
-  confirmClose: () => ipcRenderer.invoke('confirm-close')
+  confirmClose: () => ipcRenderer.invoke('confirm-close'),
+  isPackaged: () => ipcRenderer.invoke('is-packaged')
 }
 
 

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -1490,7 +1490,7 @@ function canEdit({ selectedFiles }) {
 
 async function removeBoardFolder(fullPath) {
   // TODO: Replace with getting the file tree from the board and deleting one by one
-  let output = await serial.execFile('./ui/arduino/helpers.py')
+  let output = await serial.execFile(await getHelperFullPath())
   await serial.run(`delete_folder('${fullPath}')`)
 }
 
@@ -1522,7 +1522,7 @@ async function uploadFolder(srcPath, destPath, dataConsumer) {
 async function downloadFolder(srcPath, destPath, dataConsumer) {
   dataConsumer = dataConsumer || function() {}
   await disk.createFolder(destPath)
-  let output = await serial.execFile('./ui/arduino/helpers.py')
+  let output = await serial.execFile(await getHelperFullPath())
   output = await serial.run(`ilist_all('${srcPath}')`)
   let files = []
   try {
@@ -1548,5 +1548,22 @@ async function downloadFolder(srcPath, destPath, dataConsumer) {
         serial.getFullPath(destPath, relativePath, '')
       )
     }
+  }
+}
+
+async function getHelperFullPath() {
+  const appPath = await disk.getAppPath()
+  if (await win.isPackaged()) {
+    return disk.getFullPath(
+      appPath,
+      '..',
+      'ui/arduino/helpers.py'
+    )
+  } else {
+    return disk.getFullPath(
+      appPath,
+      'ui/arduino/helpers.py',
+      ''
+    )
   }
 }


### PR DESCRIPTION
# Problem

![VirtualBox_WinDev2311Eval_24_04_2024_18_13_10](https://github.com/arduino/lab-micropython-editor/assets/954594/8cb97e8c-5d73-44cf-ada0-c39dd539eb62)

On Windows and Linux, when packaged, the app lives inside an `asar` file.
This causes issues getting the full path for the `helpers.py` file to be executed.

# Solution

There are several ways to go around this issue. 
I used electron builder's `extraResources` to include the `helper.py` file inside the `resources` folder on the packaged app.
This way the correct absolute path is resolved when the package is built.

# Testing

The operations that use the helper are remove folder (from the board) and upload folder.

Probably needs some more extensive testing on MacOS. 
It looks like it's working for Linux and Windows.

