### PR TITLE
Stuck in loading files

### DIFF
--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -406,24 +406,36 @@ async function store(state, emitter) {
     emitter.emit('render')
 
     if (state.isConnected) {
-      state.boardFiles = await getBoardFiles(
-        serial.getFullPath(
-          state.boardNavigationRoot,
-          state.boardNavigationPath,
-          ''
+      try {
+        state.boardFiles = await getBoardFiles(
+          serial.getFullPath(
+            state.boardNavigationRoot,
+            state.boardNavigationPath,
+            ''
+          )
         )
-      )
+      } catch (e) {
+        state.boardFiles = []
+      }
     } else {
       state.boardFiles = []
     }
 
-    state.diskFiles = await getDiskFiles(
-      disk.getFullPath(
-        state.diskNavigationRoot,
-        state.diskNavigationPath,
-        ''
+    try {
+      state.diskFiles = await getDiskFiles(
+        disk.getFullPath(
+          state.diskNavigationRoot,
+          state.diskNavigationPath,
+          ''
+        )
       )
-    )
+    } catch (e) {
+      state.diskNavigationRoot = null
+      state.diskNavigationPath = '/'
+      state.isLoadingFiles = false
+      emitter.emit('render')
+      return
+    }
 
     emitter.emit('refresh-selected-files')
     state.isLoadingFiles = false


### PR DESCRIPTION
# Problem:

In order to use the editor there must be a folder setup for saving/loading local files.
This is the initial condition at first loading of the app.
If the selected folder gets renamed, deleted or moved, the app gets stuck loading files.

Issue: #135 

# How to reproduce

1. Open Arduino Lab for MicroPython
2. Select local folder if needed
3. Exit Arduino Lab for MicroPython
4. Rename selected local folder
5. Open Arduino Lab for MicroPython again

This should make the app stuck in loading files.

# Fast solution:

1. Open the file explorer and paste `%APPDATA%` on the address bar
2. Remove the folder `Arduino Lab for MicroPython`

![VirtualBox_WinDev2311Eval_05_11_2024_10_10_58](https://github.com/user-attachments/assets/7b115d63-15c9-4238-b854-5342c21abf9e)

![VirtualBox_WinDev2311Eval_05_11_2024_10_14_05](https://github.com/user-attachments/assets/cf7347f2-4d9b-4846-b32f-e92c9bdfd61d)

# Bugfix solution:

If refresh local files fail, make user pick a folder again.