### PR TITLE
Removed automatic creation of lib folder.

### DIFF
--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -117,10 +117,6 @@ async function store(state, emitter) {
     // Recover from getting stuck in raw repl
     await serial.getPrompt()
 
-    // Make sure there is a lib folder
-    log('creating lib folder')
-    await serial.createFolder('/lib')
-
     // Connected and ready
     state.isConnecting = false
     state.isConnected = true


### PR DESCRIPTION
When we created this feature, to teach users to keep their libraries in a place other than the root, the editor did not have the ability to create folders.
Now this feature is present, and creating it for the user is no longer necessary.