### PR TITLE
Prompting to save before quit also for new files

### DIFF
--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -369,7 +369,7 @@ async function store(state, emitter) {
   emitter.on('close-tab', (id) => {
     log('close-tab', id)
     const currentTab = state.openFiles.find(f => f.id === id)
-    if (currentTab.hasChanges && currentTab.parentFolder !== null) {
+    if (currentTab.hasChanges) {
       let response = confirm("Your file has unsaved changes. Are you sure you want to proceed?")
       if (!response) return false
     }

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -1324,7 +1324,7 @@ async function store(state, emitter) {
   })
 
   win.beforeClose(async () => {
-    const hasChanges = !!state.openFiles.find(f => f.parentFolder && f.hasChanges)
+    const hasChanges = !!state.openFiles.find(f => f.hasChanges)
     if (hasChanges) {
       const response = await confirm('You may have unsaved changes. Are you sure you want to proceed?', 'Yes', 'Cancel')
       if (!response) return false


### PR DESCRIPTION
# Context

When the editor opens it creates an "empty" file and show that to the user at start.
When closing the editor, it will check for unsaved changes on the opened tabs and prompt the user if they are really sure they want to quit.

# Problem

![image](https://github.com/user-attachments/assets/a2e5f9b9-76ed-403b-b6cc-bc96d486efe6)

The new file that appears at the start of the editor is not part of the "check for unsaved changes" because that file has never been saved. Apparently this is due people thinking they had saved their code using "cmd+s" or "ctrl+s".

# Solution

When quitting the app, include the "new files" on the check for unsaved changes.