### PR TITLE
Fix path resolution

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -60,7 +60,7 @@ const Serial = {
     return board.fs_save(content || ' ', filename, dataConsumer)
   },
   uploadFile: async (src, dest, dataConsumer) => {
-    return board.fs_put(src, dest, dataConsumer)
+    return board.fs_put(src, dest.replaceAll(path.win32.sep, path.posix.sep), dataConsumer)
   },
   downloadFile: async (src, dest) => {
     let contents = await Serial.loadFile(src)

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -1509,7 +1509,7 @@ async function uploadFolder(srcPath, destPath, dataConsumer) {
   let allFiles = await disk.ilistAllFiles(srcPath)
   for (let i in allFiles) {
     const file = allFiles[i]
-    const relativePath = file.path.substring(srcPath.length+1)
+    const relativePath = file.path.substring(srcPath.length)
     if (file.type === 'folder') {
       await serial.createFolder(
         serial.getFullPath(

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -1509,7 +1509,7 @@ async function uploadFolder(srcPath, destPath, dataConsumer) {
   let allFiles = await disk.ilistAllFiles(srcPath)
   for (let i in allFiles) {
     const file = allFiles[i]
-    const relativePath = file.path.substring(srcPath.length)
+    const relativePath = file.path.substring(srcPath.length+1)
     if (file.type === 'folder') {
       await serial.createFolder(
         serial.getFullPath(
@@ -1523,7 +1523,7 @@ async function uploadFolder(srcPath, destPath, dataConsumer) {
         disk.getFullPath(srcPath, relativePath, ''),
         serial.getFullPath(destPath, relativePath, ''),
         (progress) => {
-          dataConsumer(progress, relativePath.slice(1))
+          dataConsumer(progress, relativePath)
         }
       )
     }


### PR DESCRIPTION
# Problem

On windows, recursively upload of folders breaks and files are uploaded with leading \ and other characters.

While manual creation of folders and uploads of files within newly created folders works, if the user tries to upload a whole folder, the recursive process creates the folder at destination, as per `createFolder` action, but the files within the folders are uploaded with an unsanitized path, containing Windows' back-slash, hence “creating” a file with a name containing a “broken” path.

Slashes should be sanitized when it comes to destination path.

# How to reproduce

On your local filesystem create a folder named `test_folder`

Enter this folder and create 2 files:
- test1.py
- test2.py

The files can be empty

Connect your board, select the folder and “upload” it as a whole.

# Solution

Making sure relative path won't contain initial separator.

![image](https://github.com/user-attachments/assets/1d6b5d95-4ddf-438d-ae62-2685ded08ab8)
