### PR TITLE
Bugfix Windows missing cursor on editor

### DIFF
--- a/backend/ipc.js
+++ b/backend/ipc.js
@@ -6,7 +6,7 @@ const {
   getAllFiles
 } = require('./helpers.js')
 
-module.exports = function registerIPCHandlers(win, ipcMain, app) {
+module.exports = function registerIPCHandlers(win, ipcMain, app, dialog) {
   ipcMain.handle('open-folder', async (event) => {
     console.log('ipcMain', 'open-folder')
     const folder = await openFolderDialog(win)
@@ -121,6 +121,12 @@ module.exports = function registerIPCHandlers(win, ipcMain, app) {
   ipcMain.handle('get-app-path', () => {
     console.log('ipcMain', 'get-app-path')
     return app.getAppPath()
+  })
+
+  ipcMain.handle('open-dialog', (event, opt) => {
+    console.log('ipcMain', 'open-dialog', opt)
+    const response = dialog.showMessageBoxSync(win, opt)
+    return response != opt.cancelId
   })
 
   win.on('close', (event) => {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain } = require('electron')
+const { app, BrowserWindow, ipcMain, dialog } = require('electron')
 const path = require('path')
 const fs = require('fs')
 
@@ -49,7 +49,7 @@ function createWindow () {
     win.show()
   })
 
-  registerIPCHandlers(win, ipcMain, app)
+  registerIPCHandlers(win, ipcMain, app, dialog)
   registerMenu(win)
 
   app.on('activate', () => {

--- a/preload.js
+++ b/preload.js
@@ -157,7 +157,8 @@ const Window = {
   },
   beforeClose: (callback) => ipcRenderer.on('check-before-close', callback),
   confirmClose: () => ipcRenderer.invoke('confirm-close'),
-  isPackaged: () => ipcRenderer.invoke('is-packaged')
+  isPackaged: () => ipcRenderer.invoke('is-packaged'),
+  openDialog: (opt) => ipcRenderer.invoke('open-dialog', opt)
 }
 
 

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -8,6 +8,19 @@ const newFileContent = `# This program was created in Arduino Lab for MicroPytho
 print('Hello, MicroPython!')
 `
 
+async function confirm(msg, cancelMsg, confirmMsg) {
+  cancelMsg = cancelMsg || 'Cancel'
+  confirmMsg = confirmMsg || 'Yes'
+  let response = await win.openDialog({
+    type: 'question',
+    buttons: [cancelMsg, confirmMsg],
+    cancelId: 0,
+    message: msg
+  })
+  console.log('confirm', response)
+  return Promise.resolve(response)
+}
+
 async function store(state, emitter) {
   win.setWindowSize(720, 640)
 
@@ -313,7 +326,7 @@ async function store(state, emitter) {
     }
 
     if (willOverwrite) {
-      const confirmation = confirm(`You are about to overwrite the file ${openFile.fileName} on your ${openFile.source}.\n\n Are you sure you want to proceed?`, 'Cancel', 'Yes')
+      const confirmation = await confirm(`You are about to overwrite the file ${openFile.fileName} on your ${openFile.source}.\n\n Are you sure you want to proceed?`, 'Cancel', 'Yes')
       if (!confirmation) {
         state.isSaving = false
         openFile.parentFolder = oldParentFolder
@@ -366,11 +379,11 @@ async function store(state, emitter) {
     state.editingFile = id
     emitter.emit('render')
   })
-  emitter.on('close-tab', (id) => {
+  emitter.on('close-tab', async (id) => {
     log('close-tab', id)
     const currentTab = state.openFiles.find(f => f.id === id)
     if (currentTab.hasChanges) {
-      let response = confirm("Your file has unsaved changes. Are you sure you want to proceed?")
+      let response = await confirm("Your file has unsaved changes. Are you sure you want to proceed?")
       if (!response) return false
     }
     state.openFiles = state.openFiles.filter(f => f.id !== id)
@@ -474,7 +487,7 @@ async function store(state, emitter) {
         fileName: value
       })
       if (willOverwrite) {
-        const confirmAction = confirm(`You are about to overwrite the file ${value} on your board.\n\nAre you sure you want to proceed?`, 'Cancel', 'Yes')
+        const confirmAction = await confirm(`You are about to overwrite the file ${value} on your board.\n\nAre you sure you want to proceed?`, 'Cancel', 'Yes')
         if (!confirmAction) {
           state.creatingFile = null
           emitter.emit('render')
@@ -497,7 +510,7 @@ async function store(state, emitter) {
         fileName: value
       })
       if (willOverwrite) {
-        const confirmAction = confirm(`You are about to overwrite the file ${value} on your disk.\n\nAre you sure you want to proceed?`, 'Cancel', 'Yes')
+        const confirmAction = await confirm(`You are about to overwrite the file ${value} on your disk.\n\nAre you sure you want to proceed?`, 'Cancel', 'Yes')
         if (!confirmAction) {
           state.creatingFile = null
           emitter.emit('render')
@@ -545,7 +558,7 @@ async function store(state, emitter) {
         fileName: value
       })
       if (willOverwrite) {
-        const confirmAction = confirm(`You are about to overwrite ${value} on your board.\n\nAre you sure you want to proceed?`, 'Cancel', 'Yes')
+        const confirmAction = await confirm(`You are about to overwrite ${value} on your board.\n\nAre you sure you want to proceed?`, 'Cancel', 'Yes')
         if (!confirmAction) {
           state.creatingFolder = null
           emitter.emit('render')
@@ -574,7 +587,7 @@ async function store(state, emitter) {
         fileName: value
       })
       if (willOverwrite) {
-        const confirmAction = confirm(`You are about to overwrite ${value} on your disk.\n\nAre you sure you want to proceed?`, 'Cancel', 'Yes')
+        const confirmAction = await confirm(`You are about to overwrite ${value} on your disk.\n\nAre you sure you want to proceed?`, 'Cancel', 'Yes')
         if (!confirmAction) {
           state.creatingFolder = null
           emitter.emit('render')
@@ -631,7 +644,7 @@ async function store(state, emitter) {
     }
 
     message += `Are you sure you want to proceed?`
-    const confirmAction = confirm(message, 'Cancel', 'Yes')
+    const confirmAction = await confirm(message, 'Cancel', 'Yes')
     if (!confirmAction) {
       state.isRemoving = false
       emitter.emit('render')
@@ -719,7 +732,7 @@ async function store(state, emitter) {
         let message = `You are about to overwrite the following file/folder on your board:\n\n`
         message += `${value}\n\n`
         message += `Are you sure you want to proceed?`
-        const confirmAction = confirm(message, 'Cancel', 'Yes')
+        const confirmAction = await confirm(message, 'Cancel', 'Yes')
         if (!confirmAction) {
           state.isSaving = false
           state.renamingFile = null
@@ -758,7 +771,7 @@ async function store(state, emitter) {
         let message = `You are about to overwrite the following file/folder on your disk:\n\n`
         message += `${value}\n\n`
         message += `Are you sure you want to proceed?`
-        const confirmAction = confirm(message, 'Cancel', 'Yes')
+        const confirmAction = await confirm(message, 'Cancel', 'Yes')
         if (!confirmAction) {
           state.isSaving = false
           state.renamingFile = null
@@ -913,7 +926,7 @@ async function store(state, emitter) {
     }
 
     if (willOverwrite) {
-      const confirmation = confirm(`You are about to overwrite the file ${openFile.fileName} on your ${openFile.source}.\n\n Are you sure you want to proceed?`, 'Cancel', 'Yes')
+      const confirmation = await confirm(`You are about to overwrite the file ${openFile.fileName} on your ${openFile.source}.\n\n Are you sure you want to proceed?`, 'Cancel', 'Yes')
       if (!confirmation) {
         state.renamingTab = null
         state.isSaving = false
@@ -1175,7 +1188,7 @@ async function store(state, emitter) {
       willOverwrite.forEach(f => message += `${f.fileName}\n`)
       message += `\n`
       message += `Are you sure you want to proceed?`
-      const confirmAction = confirm(message, 'Cancel', 'Yes')
+      const confirmAction = await confirm(message, 'Cancel', 'Yes')
       if (!confirmAction) {
         state.isTransferring = false
         emitter.emit('render')
@@ -1240,7 +1253,7 @@ async function store(state, emitter) {
       willOverwrite.forEach(f => message += `${f.fileName}\n`)
       message += `\n`
       message += `Are you sure you want to proceed?`
-      const confirmAction = confirm(message, 'Cancel', 'Yes')
+      const confirmAction = await confirm(message, 'Cancel', 'Yes')
       if (!confirmAction) {
         state.isTransferring = false
         emitter.emit('render')
@@ -1327,7 +1340,7 @@ async function store(state, emitter) {
   win.beforeClose(async () => {
     const hasChanges = !!state.openFiles.find(f => f.hasChanges)
     if (hasChanges) {
-      const response = await confirm('You may have unsaved changes. Are you sure you want to proceed?', 'Yes', 'Cancel')
+      const response = await confirm('You may have unsaved changes. Are you sure you want to proceed?', 'Cancel', 'Yes')
       if (!response) return false
     }
     await win.confirmClose()


### PR DESCRIPTION
# Problem

https://github.com/arduino/lab-micropython-editor/issues/141

# How to reproduce

This bug on the cursor happens every time a "confirmation" dialog is triggered. You can trigger it by:
- Removing a file
- Trying to close the window with unsaved changes and clicking "cancel"
- Performing overwriting operations

# Solution

Switch from frontend `confirm` to use Electron's `dialog.showMessageBoxSync`. 
https://www.electronjs.org/docs/latest/api/dialog#dialogshowmessageboxsyncwndow-options