### PR TITLE
Css/expand line numbers column

### DIFF
--- a/ui/arduino/main.css
+++ b/ui/arduino/main.css
@@ -131,7 +131,7 @@ button.small .icon {
 
 #tabs {
   display: flex;
-  padding: 10px 10px 0px 40px;
+  padding: 10px 10px 0px 60px;
   align-items: center;
   gap: 10px;
   align-self: stretch;
@@ -231,7 +231,7 @@ button.small .icon {
 #code-editor .cm-gutters {
   background-color: #ECF1F1;
   border-right: none;
-  width: 40px;
+  width: 60px;
   font-size: 14px;
 }
 


### PR DESCRIPTION
The line numbers column truncated above 3 digits, making it look like numbers after 999 wrapped back to 000.
Because of how the current layout is structured, making this column dynamic would require dynamic alignment of tabs based on the width of this column, so for now the fixed width has been expanded to 60px