### PR TITLE
Hide navigation dots (..) when navigation path is root.

### DIFF
--- a/ui/arduino/views/components/file-list.js
+++ b/ui/arduino/views/components/file-list.js
@@ -104,15 +104,18 @@ function generateFileList(source) {
       }
       return 0
     })
+    const parentNavigationDots = html`<div class="item"
+  onclick=${() => emit(`navigate-${source}-parent`)}
+  style="cursor: pointer"
+  >
+  ..
+</div>`
+
     const list = html`
       <div class="file-list">
         <div class="list">
-          <div class="item"
-            onclick=${() => emit(`navigate-${source}-parent`)}
-            style="cursor: pointer"
-            >
-            ..
-          </div>
+          ${source === 'disk' && state.diskNavigationPath != '/' ? parentNavigationDots : ''}
+          ${source === 'board' && state.boardNavigationPath != '/' ? parentNavigationDots : ''}
           ${state.creatingFile == source ? newFileItem : null}
           ${state.creatingFolder == source ? newFolderItem : null}
           ${files.map(FileItem)}


### PR DESCRIPTION
This PR serves the purpose of hiding the navigation dots (`..` ) when the current navigation path for board or disk is the designated root.

This means that when `boardNavigationPath` is the board's root or `diskNavigationPath` is the user selected folder, the `..` will not appear.

This change has been requested internally as a UX enhancement, since the affordance serves no purpose and no further upwards navigation is possible.

![CleanShot 2024-12-07 at 09 15 20@2x](https://github.com/user-attachments/assets/ec80877a-54f2-4901-a754-4cbf4cfac9cc)
![CleanShot 2024-12-07 at 09 15 50@2x](https://github.com/user-attachments/assets/61b4d1f8-2c39-4f39-9781-5c2880bd1dd1)
![CleanShot 2024-12-07 at 09 16 40@2x](https://github.com/user-attachments/assets/9820a7e2-44e7-491d-a36b-3e51abfbe42e)
