### PR TITLE
Ability to run code selection

### DIFF
--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -193,7 +193,23 @@ async function store(state, emitter) {
   emitter.on('run', async () => {
     log('run')
     const openFile = state.openFiles.find(f => f.id == state.editingFile)
-    const code = openFile.editor.editor.state.doc.toString()
+    let code = openFile.editor.editor.state.doc.toString()
+
+    // If there is a selection, run only the selected code
+    const startIndex = openFile.editor.editor.state.selection.ranges[0].from
+    const endIndex = openFile.editor.editor.state.selection.ranges[0].to
+    if (endIndex - startIndex > 0) {
+      selectedCode = openFile.editor.editor.state.doc.toString().substring(startIndex, endIndex)
+      // Checking to see if the user accidentally double-clicked some whitespace
+      // While a random selection would yield an error when executed, 
+      // selecting only whitespace would not and the user would have no feedback.
+      // This check only replaces the full content of the currently selected tab
+      // with a text selection if the selection is not empty and contains only whitespace.
+      if (selectedCode.trim().length > 0) {
+        code = selectedCode
+      }
+    }
+    
     emitter.emit('open-panel')
     emitter.emit('render')
     try {


### PR DESCRIPTION
This PR enables running a selected portion of the currently open script.
It also handles the accidental selection triggered by double-clicking a whitespace area.
In a normal case running whitespace would yield no error, compared to accidentally selecting a portion of malformed code.
If whitespace is selected, the whole script will be executed.