### PR TITLE
Fixed folder icon background

### DIFF
--- a/ui/arduino/media/folder.svg
+++ b/ui/arduino/media/folder.svg
@@ -3,7 +3,7 @@
 <svg width="100%" height="100%" viewBox="0 0 64 64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;">
     <g transform="matrix(1,0,0,1,-84,-78.6667)">
         <g transform="matrix(1.04918,0,0,0.989691,79.8033,1.47079)">
-            <rect x="4" y="78" width="61" height="64.667" style="fill:white;"/>
+            <rect x="4" y="78" width="61" height="64.667" style="fill:none;"/>
         </g>
         <g transform="matrix(2,0,0,2,94,92.6667)">
             <path d="M0,18L0,0L7,0L11,4L22,4L22,8" style="fill:none;fill-rule:nonzero;stroke:black;stroke-width:2px;"/>


### PR DESCRIPTION
Fill was set to `white`, making the folder icon in the file manager stand out