### PR TITLE
Fix event handlers for file save and upload

### DIFF
--- a/backend/serial/serial-bridge.js
+++ b/backend/serial/serial-bridge.js
@@ -53,10 +53,23 @@ const SerialBridge = {
     return await ipcRenderer.invoke('serial', 'removeFile', file)
   },
   saveFileContent: async (filename, content, dataConsumer) => {
-    return await ipcRenderer.invoke('serial', 'saveFileContent', filename, content, dataConsumer)
+    if (ipcRenderer.listeners("serial-on-file-save-progress").length > 0) {
+      ipcRenderer.removeAllListeners("serial-on-file-save-progress")
+    }
+    ipcRenderer.on('serial-on-file-save-progress', (event, progress) => {
+      dataConsumer(progress)
+    })
+    return await ipcRenderer.invoke('serial', 'saveFileContent', filename, content)
   },
   uploadFile: async (src, dest, dataConsumer) => {
-    return await ipcRenderer.invoke('serial', 'uploadFile', src, dest, dataConsumer)
+    if (ipcRenderer.listeners("serial-on-upload-progress").length > 0) {
+      ipcRenderer.removeAllListeners("serial-on-upload-progress")
+    }
+
+    ipcRenderer.on('serial-on-upload-progress', (event, progress) => {
+      dataConsumer(progress)
+    })
+    return await ipcRenderer.invoke('serial', 'uploadFile', src, dest)
   },
   downloadFile: async (src, dest) => {
     let contents = await ipcRenderer.invoke('serial', 'loadFile', src)

--- a/backend/serial/serial.js
+++ b/backend/serial/serial.js
@@ -1,4 +1,5 @@
 const MicroPython = require('micropython.js')
+const path = require('path')
 
 class Serial {
     constructor(win = null) {
@@ -79,12 +80,16 @@ class Serial {
         return await this.board.fs_rm(file)
     }
 
-    async saveFileContent(filename, content, dataConsumer) {
-        return await this.board.fs_save(content || ' ', filename, dataConsumer)
+    async saveFileContent(filename, content) {
+        return await this.board.fs_save(content || ' ', filename, (progress) => {
+            this.win.webContents.send('serial-on-file-save-progress', progress)
+        })
     }
 
-    async uploadFile(src, dest, dataConsumer) {
-        return await this.board.fs_put(src, dest.replaceAll(path.win32.sep, path.posix.sep), dataConsumer)
+    async uploadFile(src, dest) {
+        return await this.board.fs_put(src, dest.replaceAll(path.win32.sep, path.posix.sep), (progress) => {
+            this.win.webContents.send('serial-on-upload-progress', progress)
+        })
     }
 
     async renameFile(oldName, newName) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arduino-lab-micropython-ide",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arduino-lab-micropython-ide",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arduino-lab-micropython-ide",
   "productName": "Arduino Lab for MicroPython",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Arduino Lab for MicroPython is a project sponsored by Arduino, based on original work by Murilo Polese.\nThis is an experimental pre-release software, please direct any questions exclusively to Github issues.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes an issue that causes the file transfer to fail. Reason is that the function callbacks cannot be serialized and need to be replaced with the IPC event handling system.