### PR TITLE
Removed ESC from global shortcuts to locally handle it in dialog.

### DIFF
--- a/backend/shortcuts.js
+++ b/backend/shortcuts.js
@@ -11,7 +11,6 @@ module.exports = {
     CLEAR_TERMINAL: 'CommandOrControl+L',
     EDITOR_VIEW: 'CommandOrControl+Alt+1',
     FILES_VIEW: 'CommandOrControl+Alt+2',
-    ESC: 'Escape'
   },
   menu: {
     CONNECT: 'CmdOrCtrl+Shift+C',

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -1447,11 +1447,11 @@ async function store(state, emitter) {
       if (state.view != 'editor') return
       emitter.emit('change-view', 'file-manager')
     }
-    if (key === shortcuts.ESC) {
-      if (state.isConnectionDialogOpen) {
-        emitter.emit('close-connection-dialog')
-      }
-    }
+    // if (key === shortcuts.ESC) {
+    //   if (state.isConnectionDialogOpen) {
+    //     emitter.emit('close-connection-dialog')
+    //   }
+    // }
 
   })
 

--- a/ui/arduino/views/components/connection-dialog.js
+++ b/ui/arduino/views/components/connection-dialog.js
@@ -6,6 +6,19 @@ function ConnectionDialog(state, emit) {
     }
   }
 
+  function onKeyDown(e) {
+    if (e.key.toLowerCase() === 'escape') {
+      emit('close-connection-dialog')
+    }
+  }
+
+  // Add/remove event listener based on dialog state
+  if (state.isConnectionDialogOpen) {
+    document.addEventListener('keydown', onKeyDown)
+  } else {
+    document.removeEventListener('keydown', onKeyDown)
+  }
+
   return html`
     <div id="dialog" class="${stateClass}" onclick=${onClick}>
       <div class="dialog-content">


### PR DESCRIPTION
I introduced a bug setting `ESC` as a global shortcut.
The `onKeyDown` event in the file-list would not be passed to the `<input>` field with the file/folder name to trigger a `.blur()` and cancel the creation of a file/folder