### PR TITLE
WIN: Sanitised path in getFullPath() to convert Windows separators to posix.

### DIFF
--- a/backend/serial/serial-bridge.js
+++ b/backend/serial/serial-bridge.js
@@ -97,7 +97,7 @@ const SerialBridge = {
     return path.posix.join(navigation, target)
   },
   getFullPath: (root, navigation, file) => {
-    return path.posix.join(root, navigation, file)
+    return path.posix.join(root, navigation.replaceAll(path.win32.sep, path.posix.sep), file.replaceAll(path.win32.sep, path.posix.sep))
   },
   getParentPath: (navigation) => {
     return path.posix.dirname(navigation)


### PR DESCRIPTION
Because of how the path was built, the second part was still using the windows separator, making file transfers fail when uploading from windows.
This PR replaces every occurrence of the Windows separator with the posix one.
The behaviour on Mac/Linux does not change, as posix separators are left untouched.