### PR TITLE
Actions v4 + Mac Universal build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
             npm run build
 
       - name: Upload [GitHub Actions]
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.JOB_TRANSFER_ARTIFACT }}
           path: dist
@@ -121,13 +121,13 @@ jobs:
 
     steps:
       - name: Download job transfer artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.JOB_TRANSFER_ARTIFACT }}
           path: ${{ env.JOB_TRANSFER_ARTIFACT }}
 
       - name: Upload tester build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact.name }}
           path: ${{ env.JOB_TRANSFER_ARTIFACT }}/${{ matrix.artifact.path }}
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download [GitHub Actions]
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.JOB_TRANSFER_ARTIFACT }}
           path: ${{ env.JOB_TRANSFER_ARTIFACT }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,8 +123,8 @@ jobs:
       - name: Download job transfer artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ matrix.artifact.name }}-${{ github.run_id }}
-          path: ${{ env.JOB_TRANSFER_ARTIFACT }}/${{ matrix.artifact.path }}
+          name: ${{ env.JOB_TRANSFER_ARTIFACT }}  # Keep this as is
+          path: ${{ env.JOB_TRANSFER_ARTIFACT }}
 
       - name: Upload tester build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,10 +27,8 @@ jobs:
             id: windows
           - os: ubuntu-latest
             id: linux
-          - os: macos-13
-            id: macos-x64
-          - os: macos-14
-            id: macos-arm64
+          - os: macos-latest
+            id: macos-universal
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 90
 
@@ -113,12 +111,9 @@ jobs:
           - path: "*-linux_x64.zip"
             name: Arduino-Lab-for-MicroPython_Linux_X86-64
             id: linux
-          - path: "*-mac_x64.zip"
-            name: Arduino-Lab-for-MicroPython_macOS_X86-64
-            id: macos-x64
-          - path: "*-mac_arm64.zip"
-            name: Arduino-Lab-for-MicroPython_macOS_arm-64
-            id: macos-arm64
+          - path: "*-mac_universal.zip"
+            name: Arduino-Lab-for-MicroPython_macOS_Universal
+            id: macos-universal
           # - path: "*Windows_64bit.exe"
           #   name: Windows_X86-64_interactive_installer
           #   id: windows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Upload tester build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact.name }}
+          name: ${{ matrix.artifact.name }}-${{ github.run_id }}
           path: ${{ env.JOB_TRANSFER_ARTIFACT }}/${{ matrix.artifact.path }}
 
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,13 @@ jobs:
       matrix:
         config:
           - os: [self-hosted, windows-sign-pc]
+            id: windows
           - os: ubuntu-latest
+            id: linux
           - os: macos-13
+            id: macos-x64
           - os: macos-14
+            id: macos-arm64
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 90
 
@@ -94,7 +98,7 @@ jobs:
       - name: Upload [GitHub Actions]
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.JOB_TRANSFER_ARTIFACT }}
+          name: ${{ env.JOB_TRANSFER_ARTIFACT }}-${{ matrix.config.id }}
           path: dist
 
   artifacts:
@@ -108,28 +112,34 @@ jobs:
         artifact:
           - path: "*-linux_x64.zip"
             name: Arduino-Lab-for-MicroPython_Linux_X86-64
+            id: linux
           - path: "*-mac_x64.zip"
             name: Arduino-Lab-for-MicroPython_macOS_X86-64
+            id: macos-x64
           - path: "*-mac_arm64.zip"
             name: Arduino-Lab-for-MicroPython_macOS_arm-64
+            id: macos-arm64
           # - path: "*Windows_64bit.exe"
           #   name: Windows_X86-64_interactive_installer
+          #   id: windows
           # - path: "*Windows_64bit.msi"
           #   name: Windows_X86-64_MSI
+          #   id: windows
           - path: "*-win_x64.zip"
             name: Arduino-Lab-for-MicroPython_Windows_X86-64
+            id: windows
 
     steps:
       - name: Download job transfer artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.JOB_TRANSFER_ARTIFACT }}  # Keep this as is
+          name: ${{ env.JOB_TRANSFER_ARTIFACT }}-${{ matrix.artifact.id }}
           path: ${{ env.JOB_TRANSFER_ARTIFACT }}
 
       - name: Upload tester build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact.name }}-${{ github.run_id }}
+          name: ${{ matrix.artifact.name }}
           path: ${{ env.JOB_TRANSFER_ARTIFACT }}/${{ matrix.artifact.path }}
 
   release:
@@ -137,23 +147,25 @@ jobs:
     if: github.repository == 'arduino/lab-micropython-editor' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - name: Download [GitHub Actions]
+      - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.JOB_TRANSFER_ARTIFACT }}
-          path: ${{ env.JOB_TRANSFER_ARTIFACT }}
+          path: artifacts
+          
+      - name: List artifacts
+        run: ls -R artifacts
 
       - name: Get Tag
         id: tag_name
         run: |
-          echo ::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}
+          echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Publish Release [GitHub]
         uses: svenstaro/upload-release-action@2.2.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           release_name: ${{ steps.tag_name.outputs.TAG_NAME }}
-          file: ${{ env.JOB_TRANSFER_ARTIFACT }}/*
+          file: artifacts/**/*
           tag: ${{ github.ref }}
           file_glob: true
 
@@ -167,7 +179,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Remove unneeded job transfer artifact
+      - name: Remove unneeded job transfer artifacts
         uses: geekyeggo/delete-artifact@v2
         with:
-          name: ${{ env.JOB_TRANSFER_ARTIFACT }}
+          name: |
+            ${{ env.JOB_TRANSFER_ARTIFACT }}-windows
+            ${{ env.JOB_TRANSFER_ARTIFACT }}-linux
+            ${{ env.JOB_TRANSFER_ARTIFACT }}-macos-x64
+            ${{ env.JOB_TRANSFER_ARTIFACT }}-macos-arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,8 +123,8 @@ jobs:
       - name: Download job transfer artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.JOB_TRANSFER_ARTIFACT }}
-          path: ${{ env.JOB_TRANSFER_ARTIFACT }}
+          name: ${{ matrix.artifact.name }}-${{ github.run_id }}
+          path: ${{ env.JOB_TRANSFER_ARTIFACT }}/${{ matrix.artifact.path }}
 
       - name: Upload tester build artifact
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "artifactName": "${productName}-${os}_${arch}.${ext}",
     "extraResources": "./ui/arduino/helpers.py",
     "mac": {
-      "target": "zip",
+      "target": [{
+        "target": "zip",
+        "arch": ["universal"]
+      }],
       "icon": "build_resources/icon.icns"
     },
     "win": {


### PR DESCRIPTION
This PR upgrades the build workflow to v4 actions.
In the process I also changed the build to produce a single MacOS Universal Binary.
This should save some resources as well.