### PR TITLE
Add fallback for Package Installer launch button

### DIFF
--- a/backend/ipc.js
+++ b/backend/ipc.js
@@ -142,6 +142,11 @@ module.exports = function registerIPCHandlers(win, ipcMain, app, dialog) {
   ipcMain.handle('launch-app', async (event, urlScheme) => {
     // Launch an external app with a custom protocol
     return new Promise((resolve, reject) => {
+      if(app.getApplicationNameForProtocol(urlScheme) === '') {        
+        resolve(false); // App not installed
+        return;
+      }
+
       try {
         shell.openExternal(urlScheme).then(() => {
           resolve(true);  // App opened successfully


### PR DESCRIPTION
Explicitly checks if there is an application installed for the package installer app scheme. This should make the fallback mechanism work on Windows.