### PR TITLE
Fix/stop on filemanager switch

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,11 +65,11 @@ app.on('ready', () => {
   createWindow()
 
   win.on('focus', () => {
-    console.log("win focus")
+    // console.log("win focus")
   })
 
   win.on('blur', () => {
-    console.log("win blur")
+    // console.log("win blur")
   })
   
 })

--- a/index.js
+++ b/index.js
@@ -65,11 +65,9 @@ app.on('ready', () => {
   createWindow()
 
   win.on('focus', () => {
-    // console.log("win focus")
   })
 
   win.on('blur', () => {
-    // console.log("win blur")
   })
   
 })

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -1627,9 +1627,7 @@ async function store(state, emitter) {
     const tabExists = state.openFiles.find(f => f.parentFolder === newFile.parentFolder && f.fileName === newFile.fileName && f.source === newFile.source)
     if (tabExists || fullPathExists) {
       const confirmation = await confirmDialog(`File ${newFile.fileName} already exists on ${source}. Please choose another name.`, 'OK')
-      if (!confirmation) {
-        return false
-      }
+      return false
     }
     // LEAK > listeners keep getting added and not removed when tabs are closed
     // additionally I found that closing a tab has actually added an extra listener

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -111,6 +111,9 @@ async function store(state, emitter) {
       }
       emitter.emit('refresh-files')
     }
+    if(view === 'file-manager') {
+      emitter.emit('stop')
+    }
     state.view = view
     emitter.emit('render')
     updateMenu()

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -160,7 +160,6 @@ async function store(state, emitter) {
         cancelId: 0,
         message: "Could not connect to the board. Reset it and try again."
       })
-      // console.log('Reset request acknowledged', response)
       emitter.emit('connection-timeout')
     }, 3500)
     try {
@@ -1196,7 +1195,6 @@ async function store(state, emitter) {
               && f.source == selectedFile.source
               && f.parentFolder == selectedFile.parentFolder
       })
-      // console.log('already open', alreadyOpen)
 
       if (!alreadyOpen) {
         // This file is not open yet,
@@ -1628,8 +1626,10 @@ async function store(state, emitter) {
     }
     const tabExists = state.openFiles.find(f => f.parentFolder === newFile.parentFolder && f.fileName === newFile.fileName && f.source === newFile.source)
     if (tabExists || fullPathExists) {
-      const confirmation = confirmDialog(`File ${newFile.fileName} already exists on ${source}. Please choose another name.`, 'OK')
-      return false
+      const confirmation = await confirmDialog(`File ${newFile.fileName} already exists on ${source}. Please choose another name.`, 'OK')
+      if (!confirmation) {
+        return false
+      }
     }
     // LEAK > listeners keep getting added and not removed when tabs are closed
     // additionally I found that closing a tab has actually added an extra listener

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -24,7 +24,6 @@ async function confirmDialog(msg, cancelMsg, confirmMsg) {
     cancelId: 1,
     message: msg
   })
-  console.log('confirm', response)
   return Promise.resolve(response)
 }
 
@@ -103,8 +102,8 @@ async function store(state, emitter) {
     }
     emitter.emit('render')
   })
+
   emitter.on('change-view', (view) => {
-    
     if (state.view === 'file-manager') {
       if (view != state.view) {
         state.selectedFiles = []
@@ -161,7 +160,7 @@ async function store(state, emitter) {
         cancelId: 0,
         message: "Could not connect to the board. Reset it and try again."
       })
-      console.log('Reset request acknowledged', response)
+      // console.log('Reset request acknowledged', response)
       emitter.emit('connection-timeout')
     }, 3500)
     try {
@@ -1197,7 +1196,7 @@ async function store(state, emitter) {
               && f.source == selectedFile.source
               && f.parentFolder == selectedFile.parentFolder
       })
-      console.log('already open', alreadyOpen)
+      // console.log('already open', alreadyOpen)
 
       if (!alreadyOpen) {
         // This file is not open yet,
@@ -1547,19 +1546,16 @@ async function store(state, emitter) {
 
   function filterDoubleRun(onlySelected = false) {
     if (preventDoubleRun) return
-    console.log('>>> RUN CODE ACTUAL <<<')
     emitter.emit('run', onlySelected)
     timedReset()
   }
 
   function runCode() {
-    console.log('>>> RUN CODE REQUEST <<<')
     if (canExecute({ view: state.view, isConnected: state.isConnected })) {
       filterDoubleRun()
     }
   }
   function runCodeSelection() {
-    console.log('>>> RUN CODE REQUEST <<<')
     if (canExecute({ view: state.view, isConnected: state.isConnected })) {
       filterDoubleRun(true)
     }
@@ -1638,7 +1634,6 @@ async function store(state, emitter) {
     // LEAK > listeners keep getting added and not removed when tabs are closed
     // additionally I found that closing a tab has actually added an extra listener
     newFile.editor.onChange = function() {
-      console.log('editor has changes')
       newFile.hasChanges = true
       emitter.emit('render')
     }


### PR DESCRIPTION
This PR addresses an issue caused by the following actions

- run a script
- switch to file manager
- open file

the app would crash because the running script's REPL output would clash with the commands.

Now switching to the file manager will stop the program first