### PR TITLE
Fix/root detection

### DIFF
--- a/ui/arduino/helpers.py
+++ b/ui/arduino/helpers.py
@@ -1,13 +1,12 @@
 import os
 import json
 import sys
-os.chdir('/')
 
 def get_root(has_flash_mount = True):
   if '/flash' in sys.path:
-    print('/flash', end = '')
+    return '/flash'
   else:
-    print('/', end = '')
+    return '/'
 
 def is_directory(path):
   return True if os.stat(path)[0] == 0x4000 else False
@@ -26,6 +25,9 @@ def get_all_files(path, array_of_files = []):
     return array_of_files
 
 
+def iget_root():
+  print(get_root(), end='')
+
 def ilist_all(path):
     print(json.dumps(get_all_files(path)))
 
@@ -38,3 +40,5 @@ def delete_folder(path):
         if file['type'] == 'folder':
             os.rmdir(file['path'])
     os.rmdir(path)
+
+os.chdir(get_root())

--- a/ui/arduino/helpers.py
+++ b/ui/arduino/helpers.py
@@ -1,6 +1,14 @@
 import os
 import json
+import sys
 os.chdir('/')
+
+def get_root(has_flash_mount = True):
+  if '/flash' in sys.path:
+    print('/flash', end = '')
+  else:
+    print('/', end = '')
+
 def is_directory(path):
   return True if os.stat(path)[0] == 0x4000 else False
 

--- a/ui/arduino/helpers.py
+++ b/ui/arduino/helpers.py
@@ -2,7 +2,7 @@ import os
 import json
 import sys
 
-def get_root(has_flash_mount = True):
+def get_root():
   if '/flash' in sys.path:
     return '/flash'
   else:

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -1694,7 +1694,7 @@ async function getAvailablePorts() {
 
 async function getBoardRoot() {
   let output = await serialBridge.execFile(await getHelperFullPath())
-  output = await serialBridge.run(`get_root()`)
+  output = await serialBridge.run(`iget_root()`)
   let boardRoot = ''
   try {
     // Extracting the json output from serial response

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -179,7 +179,7 @@ async function store(state, emitter) {
     // Connected and ready
     state.isConnecting = false
     state.isConnected = true
-    state.boardNavigationRoot = await getBoardRoot()
+    state.boardNavigationPath = await getBoardNavigationPath()
     updateMenu()
     if (state.view === 'editor' && state.panelHeight <= PANEL_CLOSED) {
       state.panelHeight = state.savedPanelHeight
@@ -1699,7 +1699,7 @@ async function getAvailablePorts() {
   return await serialBridge.loadPorts()
 }
 
-async function getBoardRoot() {
+async function getBoardNavigationPath() {
   let output = await serialBridge.execFile(await getHelperFullPath())
   output = await serialBridge.run(`iget_root()`)
   let boardRoot = ''

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -175,6 +175,7 @@ async function store(state, emitter) {
     // Connected and ready
     state.isConnecting = false
     state.isConnected = true
+    state.boardNavigationRoot = await getBoardRoot()
     updateMenu()
     if (state.view === 'editor' && state.panelHeight <= PANEL_CLOSED) {
       state.panelHeight = state.savedPanelHeight
@@ -1689,6 +1690,23 @@ function generateHash() {
 
 async function getAvailablePorts() {
   return await serialBridge.loadPorts()
+}
+
+async function getBoardRoot() {
+  let output = await serialBridge.execFile(await getHelperFullPath())
+  output = await serialBridge.run(`get_root()`)
+  let boardRoot = ''
+  try {
+    // Extracting the json output from serial response
+    output = output.substring(
+      output.indexOf('OK')+2,
+      output.indexOf('\x04')
+    )
+    boardRoot = output
+  } catch (e) {
+    log('error', output)
+  }
+  return boardRoot
 }
 
 async function getBoardFiles(path) {

--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -285,7 +285,10 @@ async function store(state, emitter) {
     }
     emitter.emit('open-panel')
     emitter.emit('render')
-    await serialBridge.getPrompt()
+    if (state.isConnected) {
+      await serialBridge.getPrompt()
+    }
+
   })
   emitter.on('reset', async () => {
     log('reset')
@@ -603,7 +606,7 @@ async function store(state, emitter) {
       }
       await serialBridge.saveFileContent(
         serialBridge.getFullPath(
-          '/',
+          state.boardNavigationRoot,
           state.boardNavigationPath,
           fileNameParameter
         ),
@@ -782,7 +785,7 @@ async function store(state, emitter) {
         if (file.source === 'board') {
           await serialBridge.removeFile(
             serialBridge.getFullPath(
-              '/',
+              state.boardNavigationRoot,
               state.boardNavigationPath,
               file.fileName
             )

--- a/ui/arduino/views/components/new-file-dialog.js
+++ b/ui/arduino/views/components/new-file-dialog.js
@@ -65,7 +65,7 @@ function NewFileDialog(state, emit) {
 ` 
   
   if (state.isNewFileDialogOpen) {
-    const el = newFileDialog.querySelector('#dialog-new-file .dialog-contents > input')
+    const el = newFileDialog.querySelector('#dialog-new-file .dialog-content > input')
     if (el) {
       el.focus()
     }


### PR DESCRIPTION
This PR introduces detection of board's default root path, which may be `/` or `/flash` depending on ports.
It seems that it will eventually standardise to `/flash` following the introduction of ROMFS.
A typical scenario will be as described in this comment related to MAPFS (later called ROMFS)
https://github.com/micropython/micropython/pull/8381#issuecomment-1982423698

```shell
/flash
/rom
/sd
```

With `/` not being directly writable unless wanted by someone producing their own custom build, but I'd rather be future-proof with this double-handling based on the presence of `/flash` in `sys.path`.

With this PR the creation of a new program will happen in `/flash` for boards which are already mounting the main file-system there and default to `/` for other platforms.
Eventually all platforms should follow custom even if a board will never use an SD card or have ROMFS