### PR TITLE
Shift focus to REPL on run.

### DIFF
--- a/ui/arduino/store.js
+++ b/ui/arduino/store.js
@@ -274,13 +274,24 @@ async function store(state, emitter) {
     }
     
     emitter.emit('open-panel')
+    el = document.querySelector('.xterm-helper-textarea')
+    if (el) {
+      el.focus()
+    }
     emitter.emit('render')
+
     try {
       await serialBridge.getPrompt()
       await serialBridge.run(code)
     } catch(e) {
       log('error', e)
     }
+    
+    el = document.querySelector('.cm-content')
+    if (el) {
+      el.focus()
+    }
+    emitter.emit('render')
   })
   emitter.on('stop', async () => {
     log('stop')


### PR DESCRIPTION
In this PR, when code is run the focus is shifted to the REPL.
This allows for REPL interaction on Run (`input`, execution control such as `CTRL+C` or even keyboard input detection).
On Stop or completion, the focus goes back to the editor where the user left