### PR TITLE
xterm styling, WebFont fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .npmrc
 Resources
 temp
+local_only

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ dist/
 .vscode
 .npmrc
 Resources
-temp
 local_only

--- a/ui/arduino/main.css
+++ b/ui/arduino/main.css
@@ -370,7 +370,7 @@ button.small .icon {
   align-items: center;
   align-self: stretch;
   position: relative;
-  background: black;
+  background: #0d1b2a;
   transition: height 0.15s;
 }
 
@@ -442,7 +442,6 @@ button.small .icon {
 }
 
 .terminal-wrapper {
-  color: white;
   width: 97%;
   margin-left: 2%;
   overflow: hidden;

--- a/ui/arduino/views/components/elements/terminal.js
+++ b/ui/arduino/views/components/elements/terminal.js
@@ -1,7 +1,35 @@
 class XTerm extends Component {
   constructor(id, state, emit) {
     super(id)
-    this.term = new Terminal()
+    this.term = new Terminal({
+      fontSize: 16,
+      fontFamily: '"CodeFont", monospace',
+      fontWeight: 'normal',
+      lineHeight: 1.2,
+      theme: {
+        background:          '#0d1b2a',
+        foreground:          '#e0eaea',
+        cursor:              '#ffffff',
+        cursorAccent:        '#0d1b2a',
+        selectionBackground: 'rgba(0, 212, 170, 0.25)',
+        black:               '#1e2d3d',
+        red:                 '#ff6b6b',
+        green:               '#4ecdc4',
+        yellow:              '#ffd166',
+        blue:                '#5b9bd5',
+        magenta:             '#c792ea',
+        cyan:                '#00d4aa',
+        white:               '#e0eaea',
+        brightBlack:         '#4a6070',
+        brightRed:           '#ff8e8e',
+        brightGreen:         '#7be4dc',
+        brightYellow:        '#ffe599',
+        brightBlue:          '#80b8e8',
+        brightMagenta:       '#d6b0f5',
+        brightCyan:          '#33dfbb',
+        brightWhite:         '#f5fafa',
+      }
+    })
     this.resizeTerm = this.resizeTerm.bind(this)
   }
 


### PR DESCRIPTION
The REPL now implements the global CodeFont for better readability.
On Linux/Windows the default font chosen was rendering poorly (#218 ).

A full colour palette is implemented, supporting a coherent ANSI output.